### PR TITLE
contributing formatting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,6 +177,7 @@ class MyS3Fetcher(core.FetchModule):
             return
         
         # Proceed with fetching...
+```
 
 ## 📝 Pull Request Guidelines
 


### PR DESCRIPTION
Example missed the closing ticks.