### PR TITLE
Configure typechecker to run on every PR

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,30 @@
+name: Typecheck
+
+on:
+  push:
+    branches: main
+  pull_request:
+    branches: '*'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  mypy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Install the latest version of uv
+      uses: astral-sh/setup-uv@v7
+
+    - name: Install dependencies
+      run: |
+        uv sync
+
+    - name: Run mypy
+      run: |
+        uv run mypy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,13 @@ test = ['pytest']
 
 full = ["fetchez[aws,vector]"]
 
+[dependency-groups]
+dev = [
+  "mypy",
+  "types-requests>=2.31.0.6",
+  "types-tqdm>=4.67.0.20241221",
+]
+
 [project.scripts]
 # CLI Entry Points
 fetchez = "fetchez.cli:fetchez_cli"
@@ -61,3 +68,24 @@ namespaces = false
 # Keys are package names. Values are globs relative to that package root.
 # Example: src/fetchez/data/*.geojson -> "data/*.geojson"
 fetchez = ["data/*.geojson"]
+
+[tool.mypy]
+mypy_path = "src"
+packages = ["fetchez"]
+python_version = "3.12"
+# strict = true
+
+[[tool.mypy.overrides]]
+module = [
+    "shapely.*",
+    "lxml.*",
+    "boto3",
+    "botocore.*",
+    "mercantile",
+    "osgeo",
+    "pyproj",
+    "sentinelsat",
+    "shapefile",
+    "yaml",
+]
+ignore_missing_imports = true


### PR DESCRIPTION
There are lots of changes to get the typechecker passing. Do you think this would be useful?

In my experience, a typechecker can help eliminate a large category of bugs and keep the code readable by ensuring that the type annotations don't go out of sync with the code.