### PR TITLE
Publish to pypi on release instead of tag

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,18 +1,19 @@
 name: Publish to PyPI
 
 on:
-  push:
-    tags:
-      - 'v*'  # Triggers only on version tags (e.g., v0.1.0, v2.3.1)
+  release:
+    types: [published]  # Triggers when you click "Publish release" in GitHub
 
 jobs:
   build-and-publish:
     name: Build and Publish
     runs-on: ubuntu-latest
 
+    environment: pypi
+
     # Permissions required for Trusted Publishing (OIDC) authentication
     permissions:
-      id-token: write  # MANDATORY for OIDC
+      id-token: write
       contents: read
 
     steps:


### PR DESCRIPTION
## Description

Changes Pypi publishing to release instead of tag. Closes #84


---

#### Checklist

- [X] PR title is descriptive
- [X] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [X] If needed, `CHANGELOG.md` updated
- [X] If needed, docs and/or `README.md` updated
- [X] If needed, unit tests added
- [X] All checks passing (comment `pre-commit.ci autofix` if pre-commit is failing)
- [X] At least one approval
