### PR TITLE
dst_fn get's set immediately in 'add_entry_to_results'; flatten hook …

### DIFF
--- a/src/fetchez/cli.py
+++ b/src/fetchez/cli.py
@@ -60,7 +60,7 @@ print_welcome_banner = print_banner_orbit  # alias for when we randomly change i
 def setup_logging(verbose=False):
     log_level = logging.INFO if verbose else logging.WARNING
 
-    logger = logging.getLogger("fetchez")
+    logger = logging.getLogger()
     logger.setLevel(log_level)
 
     if logger.hasHandlers():

--- a/src/fetchez/core.py
+++ b/src/fetchez/core.py
@@ -1171,14 +1171,14 @@ class FetchModule:
             if parsed_url.scheme == "ftp":
                 logger.info("ok")
                 status = Fetch(url=entry["url"], headers=self.headers).fetch_ftp_file(
-                    os.path.join(self._outdir, entry["dst_fn"])
+                    entry["dst_fn"]
                 )
             else:
                 status = Fetch(
                     url=entry["url"],
                     headers=self.headers,
                 ).fetch_file(
-                    os.path.join(self._outdir, entry["dst_fn"]),
+                    entry["dst_fn"],
                     check_size=check_size,
                     tries=retries,
                     verbose=verbose,
@@ -1205,8 +1205,8 @@ class FetchModule:
         added to `results`, but we need `url`, `dst_fn` and `data_type`.
         """
 
-        # if utils.str_or(dst_fn) is not None:
-        #     dst_fn = os.path.join(self._outdir, dst_fn)
+        if utils.str_or(dst_fn) is not None:
+            dst_fn = os.path.join(self._outdir, dst_fn)
         entry = {"url": url, "dst_fn": dst_fn, "data_type": data_type}
         entry.update(kwargs)
         self.results.append(entry)

--- a/src/fetchez/hooks/file_ops.py
+++ b/src/fetchez/hooks/file_ops.py
@@ -42,20 +42,21 @@ class Flatten(FetchHook):
 
     def run(self, entries):
         for mod, entry in entries:
-            if entry.get("dst_fn"):
-                entry["dst_fn"] = os.path.basename(entry["dst_fn"])
+            current_path = entry.get("dst_fn")
+            if not current_path:
+                continue
 
-            if self.mode == "root":
-                if mod.outdir:
-                    mod._outdir = mod.outdir
-                else:
-                    mod._outdir = os.getcwd()
+            filename = os.path.basename(current_path)
+            if self.mode == "cwd":
+                new_dir = os.getcwd()
 
-            elif self.mode == "cwd":
-                mod._outdir = os.getcwd()
+            elif self.mode == "root":
+                new_dir = mod.outdir if mod.outdir else os.getcwd()
 
             elif self.mode == "module":
-                pass
+                new_dir = mod._outdir
+
+            entry["dst_fn"] = os.path.join(new_dir, filename)
 
         return entries
 


### PR DESCRIPTION
…had to be updated because of this

## Description

This changes where 'dst_fn' gets set to it's full path (outdir + output fn) to be right when it's added to the entry (instead of just as it's downloaded). As a result, the 'flatten' hook had to be updated as it thought otherwise.

---

#### Checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [x] If needed, `CHANGELOG.md` updated
- [x] If needed, docs and/or `README.md` updated
- [x] If needed, unit tests added
- [x] All checks passing (comment `pre-commit.ci autofix` if pre-commit is failing)
- [ ] At least one approval
