### PR TITLE
Remove --frozen for RTD (for now)

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,5 +16,5 @@ build:
       - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv sync --group docs
 
 sphinx:
-  configuration: "docs/conf.py"
+  configuration: "docs/source/conf.py"
   fail_on_warning: true


### PR DESCRIPTION
## Description

Removes --frozen switch in .readthedocs.yaml.


---

#### Checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [x] If needed, `CHANGELOG.md` updated
- [x] If needed, docs and/or `README.md` updated
- [x] If needed, unit tests added
- [x] All checks passing (comment `pre-commit.ci autofix` if pre-commit is failing)
- [x] At least one approval


<!-- readthedocs-preview fetchez start -->
---
:mag: Docs preview: https://fetchez--132.org.readthedocs.build/en/132/

<!-- readthedocs-preview fetchez end -->