### PR TITLE
Forbid print calls with Ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,3 +129,7 @@ ignore_missing_imports = true
 extend-select = [  # Extend the default ruleset:
     "T20"  # flake8-print <https://docs.astral.sh/ruff/rules/#flake8-print-t20>
 ]
+
+[tool.ruff.lint.per-file-ignores]
+# Allow print() statements in CLI module where they are expected
+"src/fetchez/cli.py" = ["T201"]


### PR DESCRIPTION
## Description

I didn't actually fix the errors, but there are 64 print calls detected!

---

#### Checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [x] If needed, `CHANGELOG.md` updated
- [x] If needed, docs and/or `README.md` updated
- [x] If needed, unit tests added
- [x] All checks passing (comment `pre-commit.ci autofix` if pre-commit is failing)
- [x] At least one approval


<!-- readthedocs-preview fetchez start -->
---
:mag: Docs preview: https://fetchez--153.org.readthedocs.build/en/153/

<!-- readthedocs-preview fetchez end -->