### PR TITLE
cli list-hooks colors and spaces

### DIFF
--- a/src/fetchez/cli.py
+++ b/src/fetchez/cli.py
@@ -613,7 +613,7 @@ def fetchez_cli():
 
         for cat in existing_cats + remaining_cats:
             # Format header: [ Metadata ]
-            print(f"\n[ {cat.title()} ]")
+            print(f"\n{utils.CYAN}[ {cat.title()} ]{utils.RESET}")
 
             for name, cls_obj in sorted(grouped_hooks[cat], key=lambda x: x[0]):
                 desc = getattr(cls_obj, "desc", "No description")
@@ -627,7 +627,7 @@ def fetchez_cli():
 
                 # Print with origin tag in yellow
                 print(
-                    f"  {utils.colorize(name, utils.BOLD):<18} "
+                    f"  {utils.colorize(name, utils.BOLD):<26} "
                     f"{utils.colorize(f'[{origin}]', utils.YELLOW):<13} : {desc}"
                 )
 


### PR DESCRIPTION
## Description

Just makes the cli --list-hooks a little nicer to look at.

---

#### Checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [x] If needed, `CHANGELOG.md` updated
- [x] If needed, docs and/or `README.md` updated
- [x] If needed, unit tests added
- [x] All checks passing (comment `pre-commit.ci autofix` if pre-commit is failing)
- [ ] At least one approval


<!-- readthedocs-preview fetchez start -->
---
:mag: Docs preview: https://fetchez--164.org.readthedocs.build/en/164/

<!-- readthedocs-preview fetchez end -->