### PR TITLE
src_srs hard-coded in gmrt

### DIFF
--- a/src/fetchez/modules/gmrt.py
+++ b/src/fetchez/modules/gmrt.py
@@ -157,7 +157,7 @@ class GMRT(FetchModule):
                 url=req.url,
                 dst_fn=outf,
                 data_type="gmrt",
-                srs="epsg:4326", # vertical is mss
+                srs="epsg:4326",  # vertical is mss
                 bounds=self.gmrt_region,  # (w, e, s, n)
                 resolution=self.res,  # e.g., 'max' or '30m'
                 date=utils.this_date(),  # e.g., '2025' (GMRT is a synthesis)


### PR DESCRIPTION
## Description

GMRT module was still using old dlim src_srs.

---

#### Checklist

- [X] PR title is descriptive
- [X] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [X] If needed, `CHANGELOG.md` updated
- [X] If needed, docs and/or `README.md` updated
- [X] If needed, unit tests added
- [ ] All checks passing (comment `pre-commit.ci autofix` if pre-commit is failing)
- [ ] At least one approval


<!-- readthedocs-preview fetchez start -->
---
:mag: Docs preview: https://fetchez--168.org.readthedocs.build/en/168/

<!-- readthedocs-preview fetchez end -->