### PR TITLE
Setup auditing for GHA & apply preventative security practices

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+    groups:
+      gha-dependencies:
+        patterns:
+          - "*"

--- a/.github/workflows/pr-rtd-link.yml
+++ b/.github/workflows/pr-rtd-link.yml
@@ -16,7 +16,7 @@ jobs:
   autolink-rtd-previews:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "readthedocs/actions/preview@v1"
+      - uses: "readthedocs/actions/preview@b8bba1484329bda1a3abe986df7ebc80a8950333"  # v1
         with:
           project-slug: "fetchez"
           message-template: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,24 +4,20 @@ on:
   release:
     types: [published]  # Triggers when you click "Publish release" in GitHub
 
+permissions: {}
+
 jobs:
-  build-and-publish:
-    name: Build and Publish
+  build:
+    name: Build
     runs-on: ubuntu-latest
-
-    environment: pypi
-
-    # Permissions required for Trusted Publishing (OIDC) authentication
-    permissions:
-      id-token: write
-      contents: read
-
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      with:
+        persist-credentials: false
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
       with:
         python-version: '3.x'
 
@@ -33,5 +29,24 @@ jobs:
     - name: Build Package
       run: python -m build
 
+    - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
+      with:
+        name: dist
+        path: dist/
+
+  pypi-public:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/fetchez
+    permissions:
+      id-token: write
+    steps:
+    - name: Get dist artifact
+      uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7
+      with:
+        name: dist
+        path: dist/
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
 
       - name: Install dependencies
         run: uv sync --group test

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
     - name: Install the latest version of uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,28 @@
+name: "GitHub Actions Security Analysis with zizmor 🌈"
+
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - ".github/workflows/*"
+  pull_request:
+    paths:
+      - ".github/workflows/*"
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: "Run zizmor 🌈"
+    runs-on: "ubuntu-latest"
+    permissions:
+      security-events: "write" # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+    steps:
+      - name: "Checkout repository"
+        uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: "Run zizmor 🌈"
+        uses: "zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8" # v0.5.2


### PR DESCRIPTION
## Description

**These are practices we should apply to every repo!**

* zizmor: GitHub Actions security audit tool. Will add alerts in the security tab at the top
* "hashpin" all actions to immutable commit SHAs using https://github.com/mfisher87/gha-hashpinner
  * Zizmor (specifically the [impostor-commit](https://docs.zizmor.sh/audits/#impostor-commit) audit) + hashpinning protects against the type of supply chain attack that hit trivy recently (https://socket.dev/blog/trivy-under-attack-again-github-actions-compromise)
* dependabot: handle automatic updates so we don't need to manually update SHAs
* trusted publishing: Scoped write permissions to the smallest possible part of the action 

---

#### Checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [x] If needed, `CHANGELOG.md` updated
- [x] If needed, docs and/or `README.md` updated
- [x] If needed, unit tests added
- [x] All checks passing (comment `pre-commit.ci autofix` if pre-commit is failing)
- [x] At least one approval


<!-- readthedocs-preview fetchez start -->
---
:mag: Docs preview: https://fetchez--190.org.readthedocs.build/en/190/

<!-- readthedocs-preview fetchez end -->