### PR TITLE
read_timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### CHANGED
+- read_timeout in fetchez.core from None->120
+
+## [0.5.4 - 2026-04-16]
 ### Added
 - Added PresetRegistry into registry
 - Add audit_full builtin preset
+- Add GSHHG module (shorelines)
+- Add CUSP module (shorelines (US))
 
 ### CHANGED
 - Update recipe.py to use the new PresetRegistry

--- a/src/fetchez/core.py
+++ b/src/fetchez/core.py
@@ -372,7 +372,7 @@ class HttpFile(io.IOBase):
 
         # Fetch ONLY the specific bytes requested
         headers = {"Range": f"bytes={self.offset}-{end}"}
-        response = self.session.get(self.url, headers=headers)
+        response = self.session.get(self.url, headers=headers, timeout=(10, 60))
         response.raise_for_status()
 
         data = response.content
@@ -413,8 +413,8 @@ class Fetch:
         json: Optional[Dict] = None,
         tries: int = 5,
         # timeout: Optional[Union[float, Tuple]] = None,
-        timeout: Optional[float] = None,
-        read_timeout: Optional[float] = None,
+        timeout: Optional[float] = 30,
+        read_timeout: Optional[float] = 120,
     ) -> Optional[requests.Response]:
         """Fetch src_url and return the requests object (iterative retry)."""
 
@@ -508,7 +508,7 @@ class Fetch:
         datatype=None,
         overwrite=False,
         timeout=30,
-        read_timeout=None,
+        read_timeout=120,
         tries=5,
         check_size=True,
         verbose=True,


### PR DESCRIPTION
## Description

* Adjusts read_timeout in fetchez.core to 120

---

#### Checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [x] If needed, `CHANGELOG.md` updated
- [x] If needed, docs and/or `README.md` updated
- [x] If needed, unit tests added
- [x] All checks passing (comment `pre-commit.ci autofix` if pre-commit is failing)
- [ ] At least one approval


<!-- readthedocs-preview fetchez start -->
---
:mag: Docs preview: https://fetchez--207.org.readthedocs.build/en/207/

<!-- readthedocs-preview fetchez end -->