### PR TITLE
run_fetchez flat_results and cli args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Re-structure directories
 -- 'macros' go in their parent directories
 - Use click instead of argparse for CLI
+- core.run_fetchez now returns the final list of entries for use in the api and elsewhere.
+- Update run cli to allow for inherited options for modules.
+
+## BUGFIX
+- fix bug in earthdata.icesat2 for harmony fetching.
 
 ## [0.5.5 - 2026-04-24]
 ### ADDED

--- a/src/fetchez/api.py
+++ b/src/fetchez/api.py
@@ -191,10 +191,10 @@ def get(
         logger.debug(f"No results found for {module} with given parameters.")
         return []
 
-    run_fetchez([mod_instance], threads=threads)
-
+    # Grab the final results from the fetchez pipeline
+    final_results = run_fetchez([mod_instance], threads=threads)
     downloaded_files = []
-    for entry in mod_instance.results:
+    for mod, entry in final_results:  # mod_instance.results:
         if entry.get("status") == 0:
             fn = entry.get("dst_fn")
             if fn and os.path.exists(fn):

--- a/src/fetchez/cli/pipeline.py
+++ b/src/fetchez/cli/pipeline.py
@@ -101,15 +101,17 @@ class PipelineExecutor(FetchezMainGroup):
 
             mod_args = []
             for key, val in class_args.items():
-                if key in ["self",
-                           "kwargs",
-                           "src_region",
-                           "callback",
-                           "outdir",
-                           "name",
-                           "params",
-                           "hook",
-                           "weight"]:
+                if key in [
+                    "self",
+                    "kwargs",
+                    "src_region",
+                    "callback",
+                    "outdir",
+                    "name",
+                    "params",
+                    "hook",
+                    "weight",
+                ]:
                     continue
 
                 mod_args.append([f"--{key}", val["desc"], val["default"]])

--- a/src/fetchez/cli/pipeline.py
+++ b/src/fetchez/cli/pipeline.py
@@ -25,6 +25,7 @@ from fetchez.registry import (
 from fetchez.spatial import parse_region
 from fetchez.utils import (
     parse_hook_string,
+    get_class_arguments,
     colorize,
     CYAN,
     GREEN,
@@ -95,7 +96,23 @@ class PipelineExecutor(FetchezMainGroup):
 
         if mod_cls:
             help_text = getattr(mod_cls, "_cli_help_text", f"Run the {name} module.")
-            mod_args = _populate_subparser(mod_cls)
+            class_args = get_class_arguments(mod_cls)
+            # mod_args = _populate_subparser(mod_cls)
+
+            mod_args = []
+            for key, val in class_args.items():
+                if key in ["self",
+                           "kwargs",
+                           "src_region",
+                           "callback",
+                           "outdir",
+                           "name",
+                           "params",
+                           "hook",
+                           "weight"]:
+                    continue
+
+                mod_args.append([f"--{key}", val["desc"], val["default"]])
 
         if bundle_yml:
             help_text = bundle_yml.get("description", "")

--- a/src/fetchez/core.py
+++ b/src/fetchez/core.py
@@ -1006,6 +1006,7 @@ def run_fetchez(modules: List["FetchModule"], threads: int = 3, global_hooks=Non
 
     return flat_results
 
+
 # =============================================================================
 # Fetch Module (Base & Default/Test Implementations)
 #

--- a/src/fetchez/core.py
+++ b/src/fetchez/core.py
@@ -1004,6 +1004,7 @@ def run_fetchez(modules: List["FetchModule"], threads: int = 3, global_hooks=Non
         except Exception as e:
             logger.error(f'Global collection-hook "{hook.name}" failed: {e}')
 
+    return flat_results
 
 # =============================================================================
 # Fetch Module (Base & Default/Test Implementations)

--- a/src/fetchez/hooks/unzip.py
+++ b/src/fetchez/hooks/unzip.py
@@ -177,10 +177,9 @@ class Unzip(FetchHook):
             # --- .GZ DECOMPRESSION (Single File) ---
             elif lower_path.endswith(".gz"):
                 extracted_path = file_path[:-3]
-
                 if not self.overwrite and os.path.exists(extracted_path):
                     logger.debug(
-                        f"Skipping gunzip (file exists): {os.path.basename(file_path)}"
+                        f"Skipping gunzip (file exists): {os.path.basename(extracted_path)}"
                     )
                     out_entries.append(
                         (mod, {**entry, "dst_fn": extracted_path, "status": 0})

--- a/src/fetchez/modules/base.py
+++ b/src/fetchez/modules/base.py
@@ -75,8 +75,8 @@ class FetchModule:
 
         self.min_year = utils.int_or(min_year)
         self.max_year = utils.int_or(max_year)
-        self.weight = float(weight)
-        self.uncertainty = float(uncertainty)
+        self.weight = utils.float_or(weight, 1.0)
+        self.uncertainty = utils.float_or(uncertainty, 0.0)
 
         # Default Headers (Can be overridden in subclass)
         self.headers = {"User-Agent": "fetchez/0.5.0"}

--- a/src/fetchez/modules/earthdata.py
+++ b/src/fetchez/modules/earthdata.py
@@ -51,7 +51,7 @@ HARMONY_BASE_URL = "https://harmony.earthdata.nasa.gov"
     time_end="End Date (ISO 8601: 2020-02-01T00:00:00Z)",
     subset="Use Harmony API for subsetting (if supported)",
     filename_filter="Filter granules by filename pattern (wildcards supported)",
-    harmony_ping="Harmony ping query, ['status', 'pause', 'resume', 'cancel']"
+    harmony_ping="Harmony ping query, ['status', 'pause', 'resume', 'cancel']",
 )
 class EarthData(FetchModule):
     name = "earthdata"
@@ -367,7 +367,6 @@ class EarthData(FetchModule):
 
         if self.harmony_ping:
             if self.subset_job_id:
-                print('hi')
                 status = self.harmony_ping_for_status(
                     self.subset_job_id, self.harmony_ping
                 )

--- a/src/fetchez/modules/earthdata.py
+++ b/src/fetchez/modules/earthdata.py
@@ -18,6 +18,7 @@ import os
 import time
 import datetime
 import logging
+from tqdm import tqdm
 from typing import Dict, Optional
 
 from fetchez import core
@@ -50,6 +51,7 @@ HARMONY_BASE_URL = "https://harmony.earthdata.nasa.gov"
     time_end="End Date (ISO 8601: 2020-02-01T00:00:00Z)",
     subset="Use Harmony API for subsetting (if supported)",
     filename_filter="Filter granules by filename pattern (wildcards supported)",
+    harmony_ping="Harmony ping query, ['status', 'pause', 'resume', 'cancel']"
 )
 class EarthData(FetchModule):
     name = "earthdata"
@@ -178,7 +180,7 @@ class EarthData(FetchModule):
         if start_t != ".." or end_t != "..":
             harmony_data["datetime"] = f"{start_t}/{end_t}"
 
-        logger.info(f"Submitting Harmony Request for {self.short_name}...")
+        logger.debug(f"Submitting Harmony Request for {self.short_name}...")
 
         req = core.Fetch(self._harmony_url, headers=self.headers).fetch_req(
             params=harmony_data, timeout=30
@@ -225,7 +227,7 @@ class EarthData(FetchModule):
         """Execute standard CMR Granule Search."""
 
         params = self.earthdata_set_config()
-        logger.info(f"Searching CMR for {self.short_name}...")
+        logger.debug(f"Searching CMR for {self.short_name}...")
 
         req = core.Fetch(self._cmr_url).fetch_req(params=params)
 
@@ -239,7 +241,7 @@ class EarthData(FetchModule):
         except Exception as e:
             logger.error(f"Error parsing CMR response: {e}")
             return
-        logger.info(f"CMR returned {len(entries)} potential granules.")
+        logger.debug(f"CMR returned {len(entries)} potential granules.")
 
         # Prepare Shapely Polygon for precise filtering
         search_geom = None
@@ -293,80 +295,84 @@ class EarthData(FetchModule):
     def _run_harmony_subset(self):
         """Execute Harmony Subset Job."""
 
+        logger.info(f"id: {self.subset_job_id}")
         if not self.subset_job_id:
             status = self.harmony_make_request()
             if status and "jobID" in status:
                 self.subset_job_id = status["jobID"]
-                logger.info(f"Harmony Job Initiated: {self.subset_job_id}")
-                logger.info(
+                logger.debug(f"Harmony Job Initiated: {self.subset_job_id}")
+                logger.debug(
                     f"Harmony status url: {HARMONY_BASE_URL}/jobs/{self.subset_job_id}"
                 )
             else:
                 return
 
         if self.subset_job_id:
-            logger.info(f"Polling Harmony Job {self.subset_job_id}...")
+            logger.debug(f"Polling Harmony Job {self.subset_job_id}...")
 
-            while True:
-                try:
-                    status = self.harmony_ping_for_status(self.subset_job_id)
-                    if not status:
-                        time.sleep(10)
-                        continue
+            with tqdm(total=100) as pbar:
+                while True:
+                    try:
+                        status = self.harmony_ping_for_status(self.subset_job_id)
+                        if not status:
+                            time.sleep(10)
+                            continue
 
-                    progress = status.get("progress", 0)
-                    state = status.get("status", "unknown")
+                        progress = status.get("progress", 0)
+                        state = status.get("status", "unknown")
 
-                    if state == "successful":
-                        logger.info("Harmony Job Successful. Processing links...")
-                        for link in status.get("links", []):
-                            href = link.get("href", "")
-                            # Only grab data files
-                            if href.endswith((".h5", ".nc", ".tif", ".tiff")):
-                                base_name = os.path.basename(href)
-                                # Clean up query params if present
-                                if "?" in base_name:
-                                    base_name = base_name.split("?")[0]
+                        if state == "successful":
+                            logger.debug("Harmony Job Successful. Processing links...")
+                            for link in status.get("links", []):
+                                href = link.get("href", "")
+                                # Only grab data files
+                                if href.endswith((".h5", ".nc", ".tif", ".tiff")):
+                                    base_name = os.path.basename(href)
+                                    # Clean up query params if present
+                                    if "?" in base_name:
+                                        base_name = base_name.split("?")[0]
 
-                                self.add_entry_to_results(
-                                    url=href,
-                                    dst_fn=base_name,
-                                    data_type=f"{self.short_name}_subset",
-                                    job_id=self.subset_job_id,
-                                )
-                        break
+                                    self.add_entry_to_results(
+                                        url=href,
+                                        dst_fn=base_name,
+                                        data_type=f"{self.short_name}_subset",
+                                        job_id=self.subset_job_id,
+                                    )
+                            break
 
-                    elif state in ["failed", "canceled"]:
-                        logger.error(
-                            f"Harmony Job {state}: {status.get('message', '')}"
-                        )
-                        break
+                        elif state in ["failed", "canceled"]:
+                            logger.error(
+                                f"Harmony Job {state}: {status.get('message', '')}"
+                            )
+                            break
 
-                    elif state == "running":
-                        logger.info(f"Harmony Job Running: {progress}%")
+                        elif state == "running":
+                            pbar.update(float(progress) - pbar.n)
+                            logger.debug(f"Harmony Job Running: {progress}%")
+                            time.sleep(15)
+                        elif state == "paused":
+                            self.harmony_ping_for_status(self.subset_job_id, "resume")
+                            time.sleep(10)
+                        else:
+                            # queued, accepted, etc.
+                            logger.debug(f"Harmony Job Status: {state}")
+                            time.sleep(10)
+
+                    except Exception as e:
+                        logger.error(f"Harmony polling failed: {e}")
                         time.sleep(15)
-                    elif state == "paused":
-                        self.harmony_ping_for_status(self.subset_job_id, "resume")
-                        time.sleep(10)
-                    else:
-                        # queued, accepted, etc.
-                        logger.info(f"Harmony Job Status: {state}")
-                        time.sleep(10)
-
-                except Exception as e:
-                    logger.error(f"Harmony polling failed: {e}")
-                    time.sleep(15)
 
     def run(self):
         """Run the EarthData fetch module."""
 
         if self.harmony_ping:
             if self.subset_job_id:
+                print('hi')
                 status = self.harmony_ping_for_status(
                     self.subset_job_id, self.harmony_ping
                 )
                 if status:
-                    logger.info(f"Ping Status: {status.get('status')}")
+                    logger.debug(f"Ping Status: {status.get('status')}")
             return []
 
         if self.region is None:
@@ -383,7 +389,12 @@ class EarthData(FetchModule):
 # =============================================================================
 # Shortcuts
 # =============================================================================
-@cli.cli_opts(help_text="NASA IceSat2 Data (ATL03/ATL08)")
+@cli.cli_opts(
+    help_text="NASA IceSat2 Data (ATL03/ATL08)",
+    short_name="Dataset Short Name (e.g. ATL03, ATL08, MUR-JPL-L4-GLOB-v4.1)",
+    version="Dataset Version (e.g. 007)",
+    subset="Use Harmony API for subsetting (if supported)",
+)
 class IceSat2(EarthData):
     """Shortcut for IceSat2 (ATL03/ATL08) data.
 

--- a/src/fetchez/modules/local_fs.py
+++ b/src/fetchez/modules/local_fs.py
@@ -68,7 +68,7 @@ class LocalFS(FetchModule):
         search_pattern = os.path.join(self.path, f"**/*{self.ext}")
         matched_files = 0
 
-        logger.info(f"Crawling {self.path} for '{self.ext}' files...")
+        logger.debug(f"Crawling {self.path} for '{self.ext}' files...")
 
         for filepath in glob.iglob(search_pattern, recursive=True):
             file_region = None
@@ -96,5 +96,5 @@ class LocalFS(FetchModule):
                 )
                 matched_files += 1
 
-        logger.info(f"LocalFS matched {matched_files} files in {self.region}")
+        logger.debug(f"LocalFS matched {matched_files} files in {self.region}")
         return self

--- a/src/fetchez/utils.py
+++ b/src/fetchez/utils.py
@@ -658,12 +658,13 @@ def get_class_arguments(TargetCls, want_inherited=True):
         for name, data in all_params.items():
             param = data["param"]
             origin_cls = data["origin"]
+            origin_help = getattr(origin_cls, "_cli_arg_help", {})
 
             if param.default is inspect.Parameter.empty:
                 default_str = colorize("(required)", RED)
             else:
                 # default_str = f"(default: {param.default or 'None'})"
-                default_str = f"{param.default or 'None'}"
+                default_str = param.default or None# or 'None'}"
 
             type_str = ""
             if param.annotation is not inspect.Parameter.empty:
@@ -673,8 +674,10 @@ def get_class_arguments(TargetCls, want_inherited=True):
             inherit_str = ""
             if origin_cls is not TargetCls:
                 inherit_str = colorize(f" [from {origin_cls.__name__}]", CYAN)
+                desc_str = f" - {origin_help[name]}" if name in origin_help else ""
+            else:
+                desc_str = f" - {arg_help[name]}" if name in arg_help else ""
 
-            desc_str = f" - {arg_help[name]}" if name in arg_help else ""
             args_dict[name] = {
                 "type": type_str,
                 "default": default_str,

--- a/src/fetchez/utils.py
+++ b/src/fetchez/utils.py
@@ -664,7 +664,7 @@ def get_class_arguments(TargetCls, want_inherited=True):
                 default_str = colorize("(required)", RED)
             else:
                 # default_str = f"(default: {param.default or 'None'})"
-                default_str = param.default or None# or 'None'}"
+                default_str = param.default or None  # or 'None'}"
 
             type_str = ""
             if param.annotation is not inspect.Parameter.empty:


### PR DESCRIPTION
## Description

* run_fetchez now returns the final 'flat_results' for use in api and elsewhere
* use tqdm with earthdata harmony to monitor progress.
* cli inherits arguments from module parents.

---

#### Checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [x] If needed, `CHANGELOG.md` updated
- [x] If needed, docs and/or `README.md` updated
- [x] If needed, unit tests added
- [x] All checks passing (comment `pre-commit.ci autofix` if pre-commit is failing)
- [ ] At least one approval
