### PR TITLE
registry search api bugfix

### DIFF
--- a/src/fetchez/api.py
+++ b/src/fetchez/api.py
@@ -51,10 +51,10 @@ def _search_registry(registry_cls, term: Optional[str] = None) -> Dict[str, Any]
     found = {}
     term_lower = term.lower()
     for name, meta in full_reg.items():
-        desc = meta.get("desc", getattr(meta, "meta_desc", ""))
-        tags = [t.lower() for t in getattr(meta, "meta_tags", [])]
-        aliases = [a.lower() for a in getattr(meta, "meta_aliases", [])]
-        category = meta.get("category", getattr(meta, "meta_category", ""))
+        desc = meta.get("desc", meta.get("desc", ""))
+        tags = [t.lower() for t in meta.get("tags", [])]
+        aliases = [a.lower() for a in meta.get("aliases", [])]
+        category = meta.get("category", meta.get("category", ""))
 
         if (
             term_lower in name.lower()


### PR DESCRIPTION
## Description

* .get instead of getattr in registry search

---

#### Checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [x] If needed, `CHANGELOG.md` updated
- [x] If needed, docs and/or `README.md` updated
- [x] If needed, unit tests added
- [x] All checks passing (comment `pre-commit.ci autofix` if pre-commit is failing)
- [ ] At least one approval


<!-- readthedocs-preview fetchez start -->
---
:mag: Docs preview: https://fetchez--250.org.readthedocs.build/en/250/

<!-- readthedocs-preview fetchez end -->