### PR TITLE
parse_arg_to_list

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,6 +16,6 @@ authors:
 
     website: https://ciresdem.github.io/fetchez/
 title: "Fetchez"
-version: 0.6.4
-date-released: 2026-05-12
+version: 0.6.8
+date-released: 2026-05-29
 url: "https://github.com/ciresdem/fetchez"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center"><strong>Fetch geospatial data with ease.</strong></p>
 
 <p align="center">
-  <a href="https://github.com/continuous-dems/fetchez"><img src="https://img.shields.io/badge/version-0.6.5-blue.svg" alt="Version"></a>
+  <a href="https://github.com/continuous-dems/fetchez"><img src="https://img.shields.io/badge/version-0.6.8-blue.svg" alt="Version"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License"></a>
   <a href="https://www.python.org/"><img src="https://img.shields.io/badge/python-3.12+-yellow.svg" alt="Python"></a>
   <a href="https://badge.fury.io/py/fetchez"><img src="https://badge.fury.io/py/fetchez.svg" alt="PyPI version"></a>

--- a/src/fetchez/utils.py
+++ b/src/fetchez/utils.py
@@ -497,6 +497,16 @@ def fmod2dict(fmod: str, dict_args: Optional[Dict[str, Any]] = None) -> Dict[str
     return dict_args
 
 
+def parse_arg_to_list(val, cast_type):
+    if val is None:
+        return []
+    if isinstance(val, list):
+        return [cast_type(v) for v in val]
+    if isinstance(val, str) and "/" in val:
+        return [cast_type(v) for v in val.split("/")]
+    return [cast_type(val)]
+
+
 def parse_hook_string(hook_str, default_name=None):
     """Parses 'name:key=val,key2=val2' into a dictionary for recipes and pipelines.
     Safely ignores delimiters (:,=) when they are wrapped in double quotes.


### PR DESCRIPTION
## Description

Moved util function from globato to fetchez to parse common arguments from either a '/' string or list into a list.

---

#### Checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [x] If needed, `CHANGELOG.md` updated
- [x] If needed, docs and/or `README.md` updated
- [x] If needed, unit tests added
- [x] All checks passing (comment `pre-commit.ci autofix` if pre-commit is failing)
- [ ] At least one approval


<!-- readthedocs-preview fetchez start -->
---
:mag: Docs preview: https://fetchez--251.org.readthedocs.build/en/251/

<!-- readthedocs-preview fetchez end -->