### PR TITLE
core: include error/message fields from response body in download failure messages

### DIFF
--- a/src/fetchez/core.py
+++ b/src/fetchez/core.py
@@ -652,7 +652,17 @@ class Fetch:
                         if attempt < tries - 1:
                             time.sleep(2)
                             continue
-                        raise ConnectionError(f"Status {req.status_code}")
+                        status_msg = f"Status {req.status_code}"
+                        try:
+                            body = req.json()
+                            extras = ", ".join(
+                                f"{k}: {body[k]}" for k in ("error", "message") if k in body
+                            )
+                            if extras:
+                                status_msg += f" ({extras})"
+                        except Exception:
+                            pass
+                        raise ConnectionError(status_msg)
 
                     with open(part_fn, mode) as f:
                         # desc = utils.str_truncate_middle(self.url, n=60)

--- a/src/fetchez/core.py
+++ b/src/fetchez/core.py
@@ -656,7 +656,9 @@ class Fetch:
                         try:
                             body = req.json()
                             extras = ", ".join(
-                                f"{k}: {body[k]}" for k in ("error", "message") if k in body
+                                f"{k}: {body[k]}"
+                                for k in ("error", "message")
+                                if k in body
                             )
                             if extras:
                                 status_msg += f" ({extras})"


### PR DESCRIPTION
## Summary

- When a download fails with a non-2xx status code, attempt to parse the response body as JSON and append any `error` and `message` fields to the logged failure message.
- Example: `Failed to download <url>: Status 429 (error: SYSTEM_BUSY, message: Server overloaded, please slow down)`
- Falls back silently if the response body is not JSON or does not contain those fields.

## Test plan

- [ ] Trigger a 429 response from a server that returns `{"error": "SYSTEM_BUSY", "message": "..."}` and confirm the extra detail appears in the log output.
- [ ] Confirm normal 200 downloads are unaffected.
- [ ] Confirm non-JSON error responses still log cleanly without an exception.

<!-- readthedocs-preview fetchez start -->
---
:mag: Docs preview: https://fetchez--256.org.readthedocs.build/en/256/

<!-- readthedocs-preview fetchez end -->