### PR TITLE
core: retry on 429 Too Many Requests with backoff

### DIFF
--- a/src/fetchez/core.py
+++ b/src/fetchez/core.py
@@ -455,6 +455,19 @@ class Fetch:
                         current_read_timeout += 10
                     continue
 
+                elif req.status_code == 429:  # Too Many Requests
+                    retry_after = req.headers.get("Retry-After")
+                    wait_time = (
+                        int(retry_after)
+                        if retry_after and retry_after.isdigit()
+                        else 30 * (attempt + 1)
+                    )
+                    logger.warning(
+                        f"Rate limited (429) by {self.url}. Waiting {wait_time}s before retry..."
+                    )
+                    time.sleep(wait_time)
+                    continue
+
                 elif req.status_code == 416:  # Range Not Satisfiable
                     # If range fails, try fetching whole file
                     if "Range" in self.headers:


### PR DESCRIPTION
## Summary

- `Fetch.fetch_req()` previously had no handler for HTTP 429 (Too Many Requests), so rate-limited responses fell into the generic error branch and returned immediately without retrying.
- Added an explicit 429 handler that respects the `Retry-After` response header when present, and otherwise waits `30 * (attempt + 1)` seconds before retrying (30s, 60s, 90s, … up to the existing `tries` limit).
- Logs a `warning` so users can see that a rate limit was hit and the client is backing off.

## Motivation

The GBA (Global Building Atlas) WFS server at tubvsig-so2sat-vm1.srv.mwn.de returns 429 with `SYSTEM_BUSY` when under load. Without this fix, fetchez fails immediately on the first 429 instead of waiting and retrying, making GBA data unavailable during any period of server load.

## Test plan

- [ ] Confirm that a mocked 429 response causes `fetch_req` to sleep and retry rather than returning early
- [ ] Confirm that a `Retry-After: 10` header causes a 10s wait instead of the 30s default
- [ ] Manually re-run `ivert database download` against the GBA endpoint during a busy period and verify the client waits and eventually succeeds

<!-- readthedocs-preview fetchez start -->
---
:mag: Docs preview: https://fetchez--257.org.readthedocs.build/en/257/

<!-- readthedocs-preview fetchez end -->