### PR TITLE
earthdata: fix infinite poll loop on terminal Harmony job states

### DIFF
--- a/src/fetchez/modules/earthdata.py
+++ b/src/fetchez/modules/earthdata.py
@@ -310,6 +310,9 @@ class EarthData(FetchModule):
         if self.subset_job_id:
             logger.debug(f"Polling Harmony Job {self.subset_job_id}...")
 
+            # States where Harmony is still working and polling should continue.
+            _IN_PROGRESS_STATES = {"running", "paused", "accepted", "queued"}
+
             with tqdm(total=100) as pbar:
                 while True:
                     try:
@@ -346,6 +349,13 @@ class EarthData(FetchModule):
                             )
                             break
 
+                        elif state == "complete_with_errors":
+                            logger.warning(
+                                f"Harmony Job completed with errors: {status.get('message', '')}. "
+                                f"Partial results may be available."
+                            )
+                            break
+
                         elif state == "running":
                             pbar.update(float(progress) - pbar.n)
                             logger.debug(f"Harmony Job Running: {progress}%")
@@ -353,10 +363,16 @@ class EarthData(FetchModule):
                         elif state == "paused":
                             self.harmony_ping_for_status(self.subset_job_id, "resume")
                             time.sleep(10)
-                        else:
-                            # queued, accepted, etc.
+                        elif state in _IN_PROGRESS_STATES:
                             logger.debug(f"Harmony Job Status: {state}")
                             time.sleep(10)
+                        else:
+                            # Unrecognised terminal-or-unknown state — do not loop forever.
+                            logger.warning(
+                                f"Harmony Job returned unrecognised status '{state}'; "
+                                f"stopping poll."
+                            )
+                            break
 
                     except Exception as e:
                         logger.error(f"Harmony polling failed: {e}")


### PR DESCRIPTION
## Summary

- `_run_harmony_subset()` had no handler for the `"complete_with_errors"` Harmony status, causing the polling `while True` loop to fall into the `else` branch (sleep 10 s, retry) indefinitely instead of stopping.
- Any other unrecognised status had the same problem.

## Changes

- Add an explicit `elif state == "complete_with_errors"` branch: logs a warning and breaks out of the poll loop. Partial results (if any) remain available to the caller.
- Enumerate known in-progress states (`running`, `paused`, `accepted`, `queued`) explicitly, so the `else` branch now catches genuinely unknown states and breaks with a warning rather than looping forever.

## Test plan

- [ ] Submit a Harmony job and let it run to `"successful"` — polling exits normally.
- [ ] Simulate `"complete_with_errors"` by mocking `harmony_ping_for_status` — confirm warning is logged and loop exits.
- [ ] Simulate an unrecognised status string — confirm warning is logged and loop exits.

<!-- readthedocs-preview fetchez start -->
---
:mag: Docs preview: https://fetchez--258.org.readthedocs.build/en/258/

<!-- readthedocs-preview fetchez end -->