### PR TITLE
merge_hooks doesn't remove duplicates

### DIFF
--- a/src/fetchez/utils.py
+++ b/src/fetchez/utils.py
@@ -850,6 +850,33 @@ def p_f_unzip(src_file, fns=None, outdir="./", tmp_fn=False):
 # Hooks
 # =============================================================================
 def merge_hooks(global_hooks, local_hooks):
+    """Merge global and local hooks.
+
+    Order: Globals first, then Locals.
+
+    Duplicate removal has been removed to allow nested sub-pipelines,
+    but we log a debug warning if exact duplicates cross the global/local boundary.
+    """
+
+    import logging
+
+    logger = logging.getLogger(__name__)
+
+    merged = list(global_hooks)
+
+    for h in local_hooks:
+        if h in global_hooks:
+            logger.debug(
+                f"Duplicate hook '{h.name}' detected in both global and local scopes. "
+                "Preserving both to support sequential sub-pipelines."
+            )
+        merged.append(h)
+
+    return merged
+
+
+# Depreciated due to removing duplicates!
+def _merge_hooks(global_hooks, local_hooks):
     """Merge global and local hooks, removing exact duplicates.
 
     Order: Globals first, then Locals.


### PR DESCRIPTION
## Description

* merge_hooks was removing duplicate hooks, but maybe we want to use the same hook more than once...

---

#### Checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [x] If needed, `CHANGELOG.md` updated
- [x] If needed, docs and/or `README.md` updated
- [x] If needed, unit tests added
- [x] All checks passing (comment `pre-commit.ci autofix` if pre-commit is failing)
- [ ] At least one approval


<!-- readthedocs-preview fetchez start -->
---
:mag: Docs preview: https://fetchez--259.org.readthedocs.build/en/259/

<!-- readthedocs-preview fetchez end -->