### PR TITLE
set_weights get fn key

### DIFF
--- a/src/fetchez/hooks/set_weight.py
+++ b/src/fetchez/hooks/set_weight.py
@@ -35,6 +35,7 @@ class SetWeight(FetchHook):
     The 'rules' dictionary keys are matched against:
     - The module name (e.g., 'nos_hydro')
     - The 'datatype' entry field (e.g., 'bag', 'xyz')
+    - The filename, or a subset of the filename
     """
 
     name = "set-weight"
@@ -62,15 +63,20 @@ class SetWeight(FetchHook):
 
             dst_fn = entry.get("dst_fn")
             if dst_fn:
+                keys_to_check.append(dst_fn)
                 _, ext = os.path.splitext(dst_fn)
                 if ext:
                     keys_to_check.append(ext.lower().lstrip("."))
 
             assigned_weight = self.default
             match_found = False
-
             for key in keys_to_check:
-                if key in self.rules:
+                for rule_key in self.rules.keys():
+                    if rule_key.lower() in key.lower():
+                        assigned_weight = self.rules[rule_key]
+                        match_found = True
+                        break
+                if not match_found and key in self.rules:
                     assigned_weight = self.rules[key]
                     match_found = True
                     break

--- a/src/fetchez/utils.py
+++ b/src/fetchez/utils.py
@@ -850,6 +850,33 @@ def p_f_unzip(src_file, fns=None, outdir="./", tmp_fn=False):
 # Hooks
 # =============================================================================
 def merge_hooks(global_hooks, local_hooks):
+    """Merge global and local hooks.
+
+    Order: Globals first, then Locals.
+
+    Duplicate removal has been removed to allow nested sub-pipelines,
+    but we log a debug warning if exact duplicates cross the global/local boundary.
+    """
+
+    import logging
+
+    logger = logging.getLogger(__name__)
+
+    merged = list(global_hooks)
+
+    for h in local_hooks:
+        if h in global_hooks:
+            logger.debug(
+                f"Duplicate hook '{h.name}' detected in both global and local scopes. "
+                "Preserving both to support sequential sub-pipelines."
+            )
+        merged.append(h)
+
+    return merged
+
+
+# Depreciated due to removing duplicates!
+def _merge_hooks(global_hooks, local_hooks):
     """Merge global and local hooks, removing exact duplicates.
 
     Order: Globals first, then Locals.


### PR DESCRIPTION
## Description

* set_weights hook can now use the dst_fn as a key for matching


---

#### Checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [x] If needed, `CHANGELOG.md` updated
- [x] If needed, docs and/or `README.md` updated
- [x] If needed, unit tests added
- [x] All checks passing (comment `pre-commit.ci autofix` if pre-commit is failing)
- [ ] At least one approval


<!-- readthedocs-preview fetchez start -->
---
:mag: Docs preview: https://fetchez--260.org.readthedocs.build/en/260/

<!-- readthedocs-preview fetchez end -->