### PR TITLE
spatial region buffer, module entry kwargs

### DIFF
--- a/src/fetchez/hooks/stream_init.py
+++ b/src/fetchez/hooks/stream_init.py
@@ -60,6 +60,22 @@ class DataStream(FetchHook):
             kwargs_copy["weight"] = getattr(mod, "weight", 1.0)
             kwargs_copy["uncertainty"] = getattr(mod, "uncertainty", 0.0)
 
+            reserved_keys = {
+                "url",
+                "dst_fn",
+                "data_type",
+                "status",
+                "stream",
+                "src_srs",
+                "stream_type",
+                "history",
+                "weight",
+                "uncertainty",
+            }
+            for k, v in entry.items():
+                if k not in reserved_keys:
+                    kwargs_copy[k] = v
+
             dtype = entry.get("data_type")
             hook_dtype = kwargs_copy.pop("data_type", None)
             dtype = self.stream_type or hook_dtype or dtype

--- a/src/fetchez/modules/base.py
+++ b/src/fetchez/modules/base.py
@@ -73,6 +73,10 @@ class FetchModule:
         else:
             self._outdir = os.path.join(self.outdir, self.name)
 
+        self.stream_kwargs = {
+            k: v for k, v in kwargs.items() if k not in ["datatype", "data_type"]
+        }
+
         self.min_year = utils.int_or(min_year)
         self.max_year = utils.int_or(max_year)
         self.weight = utils.float_or(weight, 1.0)
@@ -262,6 +266,10 @@ class FetchModule:
                 dst_fn = os.path.join(self._outdir, dst_fn)
 
         entry = {"url": url, "dst_fn": dst_fn, "data_type": data_type}
+
+        if hasattr(self, "stream_kwargs"):
+            entry.update(self.stream_kwargs)
+
         entry.update(kwargs)
         self.results.append(entry)
 

--- a/src/fetchez/spatial.py
+++ b/src/fetchez/spatial.py
@@ -156,7 +156,12 @@ class Region:
         return Region(self.xmin, self.xmax, self.ymin, self.ymax, srs=self.srs)
 
     def buffer(
-        self, pct: float = 5, x_bv: float | None = None, y_bv: float | None = None
+        self,
+        pct: float = 5,
+        x_bv: float | None = None,
+        y_bv: float | None = None,
+        x_inc: float | None = None,
+        y_inc: float | None = None,
     ):
         """Buffer the region in place."""
 
@@ -175,6 +180,17 @@ class Region:
 
         x_bv = x_bv if x_bv else 0
         y_bv = y_bv if y_bv else 0
+
+        if x_inc is not None:
+            if y_inc is None:
+                y_inc = x_inc
+
+            tmp_x_bv = int(x_bv / x_inc) * float(x_inc)
+            tmp_y_bv = int(y_bv / y_inc) * float(y_inc)
+            if tmp_x_bv != 0:
+                x_bv = tmp_x_bv
+            if tmp_y_bv != 0:
+                y_bv = tmp_y_bv
 
         self.xmin -= x_bv
         self.xmax += x_bv


### PR DESCRIPTION
## Description

* adds x_inc and y_inc arguments to Region buffer
* Allows kwargs passed to a module to be appended to the entry for use downstream in stream-init for custom reader arguments.

---

#### Checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [x] If needed, `CHANGELOG.md` updated
- [x] If needed, docs and/or `README.md` updated
- [x] If needed, unit tests added
- [x] All checks passing (comment `pre-commit.ci autofix` if pre-commit is failing)
- [ ] At least one approval


<!-- readthedocs-preview fetchez start -->
---
:mag: Docs preview: https://fetchez--263.org.readthedocs.build/en/263/

<!-- readthedocs-preview fetchez end -->