### PR TITLE
Add region to stream.readers and associated calls

### DIFF
--- a/src/fetchez/registry.py
+++ b/src/fetchez/registry.py
@@ -550,7 +550,7 @@ class ReaderRegistry(PluginRegistry):
     user_folder = "streams/readers"
 
     @classmethod
-    def get_reader(cls, src, term: str, **kwargs):
+    def get_reader(cls, src, term: str, region=None, **kwargs):
         if term:
             profile = ProfileRegistry.get_yaml(term)
             if profile:
@@ -572,7 +572,7 @@ class ReaderRegistry(PluginRegistry):
         logger.debug(f"No reader dtype found, checking `{_ext}` in extensions")
         reader = cls.get_reader_for_ext(_ext)
         if reader:
-            return reader(src, **kwargs)
+            return reader(src, region=region, **kwargs)
 
         return None
 

--- a/src/fetchez/streams/base.py
+++ b/src/fetchez/streams/base.py
@@ -11,12 +11,21 @@ Base fetchez Reader class to create 'streams'
 :license: MIT, see LICENSE for more details.
 """
 
+from fetchez.spatial import Region
+
 
 class BaseReader:
     """The base class for fetchez data Readers"""
 
-    def __init__(self, path, **kwargs):
+    def __init__(self, path, region=None, **kwargs):
         self.path = path
+        if region is not None and not isinstance(region, Region):
+            try:
+                self.region = Region.from_list(region)
+            except Exception:
+                self.region = region
+        else:
+            self.region = region
         self.kwargs = kwargs
 
     def yield_chunks(self):


### PR DESCRIPTION
## Description

* adds 'region' to the stream.reader base class for use downstream

---

#### Checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [x] If needed, `CHANGELOG.md` updated
- [x] If needed, docs and/or `README.md` updated
- [x] If needed, unit tests added
- [x] All checks passing (comment `pre-commit.ci autofix` if pre-commit is failing)
- [ ] At least one approval


<!-- readthedocs-preview fetchez start -->
---
:mag: Docs preview: https://fetchez--264.org.readthedocs.build/en/264/

<!-- readthedocs-preview fetchez end -->