### PR TITLE
reader msg after checking if none

### DIFF
--- a/src/fetchez/hooks/stream_init.py
+++ b/src/fetchez/hooks/stream_init.py
@@ -90,10 +90,11 @@ class DataStream(FetchHook):
             # reader = ReaderRegistry.get_reader_for_ext(src.split(".")[-1])(
             #     src, **kwargs_copy
             # )
-            logger.debug(f"Stream initiated with the '{reader.name}' reader")
             if not reader:
                 logger.warning(f"No reader could be determined for {dtype}: {entry}")
                 continue
+
+            logger.debug(f"Stream initiated with the '{reader.name}' reader")
 
             raw_stream = reader.yield_chunks()
             mod.region = Region.from_list(mod.region)


### PR DESCRIPTION
## Description

Don't print out the reader name until after checking if it was correctly generated.


---

#### Checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [x] If needed, `CHANGELOG.md` updated
- [x] If needed, docs and/or `README.md` updated
- [x] If needed, unit tests added
- [x] All checks passing (comment `pre-commit.ci autofix` if pre-commit is failing)
- [ ] At least one approval


<!-- readthedocs-preview fetchez start -->
---
:mag: Docs preview: https://fetchez--270.org.readthedocs.build/en/270/

<!-- readthedocs-preview fetchez end -->