### PR TITLE
pass region in registry reader

### DIFF
--- a/src/fetchez/modules/sysu.py
+++ b/src/fetchez/modules/sysu.py
@@ -9,6 +9,9 @@ SYSU_Topo: a 1-arc-minute global bathymetry from SWOT-derived gravity using the 
 
 https://www.nature.com/articles/s41597-026-06641-5
 https://zenodo.org/records/17958545
+
+:copyright: (c) 2010 - 2026 Regents of the University of Colorado
+:license: MIT, see LICENSE for more details.
 """
 
 import logging

--- a/src/fetchez/registry.py
+++ b/src/fetchez/registry.py
@@ -560,7 +560,7 @@ class ReaderRegistry(PluginRegistry):
                 reader = cls.get_class(reader_name)
                 if reader:
                     profile_args = profile_reader.get("args", {})
-                    return reader(src, **profile_args, **kwargs)
+                    return reader(src, region=region, **profile_args, **kwargs)
             else:
                 logger.debug(f"No reader profile found, checking `{term}` data-type")
                 reader = cls.get_reader_for_dtype(term)


### PR DESCRIPTION
## Description

* get_reader in registry was eating the region parameter when using profiles.

---

#### Checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [x] If needed, `CHANGELOG.md` updated
- [x] If needed, docs and/or `README.md` updated
- [x] If needed, unit tests added
- [x] All checks passing (comment `pre-commit.ci autofix` if pre-commit is failing)
- [ ] At least one approval


<!-- readthedocs-preview fetchez start -->
---
:mag: Docs preview: https://fetchez--271.org.readthedocs.build/en/271/

<!-- readthedocs-preview fetchez end -->