### PR TITLE
fabdem module zipfile names

### DIFF
--- a/src/fetchez/modules/fabdem.py
+++ b/src/fetchez/modules/fabdem.py
@@ -117,7 +117,11 @@ class FABDEM(FetchModule):
 
                 if self._intersects(self.region, geom):
                     zip_name = props.get("zipfile_name")
-
+                    # The index has some zipfile_name's with S-# instead of S# as they are actually named
+                    zip_name = zip_name.replace("-S-", "-S")
+                    zip_name = zip_name.replace("-N-", "-N")
+                    # The index has zipfile_name's with `E180`, but all files at 180 have `W180`
+                    zip_name = zip_name.replace("E180", "W180")
                     if zip_name:
                         url = f"{FABDEM_DATA_URL}/{zip_name}"
 


### PR DESCRIPTION
## Description

* Fixes fabdem index names that are incorrect with regard to file-names we need to fetch.

---

#### Checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [x] If needed, `CHANGELOG.md` updated
- [x] If needed, docs and/or `README.md` updated
- [x] If needed, unit tests added
- [ ] All checks passing (comment `pre-commit.ci autofix` if pre-commit is failing)
- [ ] At least one approval


<!-- readthedocs-preview fetchez start -->
---
:mag: Docs preview: https://fetchez--272.org.readthedocs.build/en/272/

<!-- readthedocs-preview fetchez end -->