### PR TITLE
forceAsync: true in Harmony request (earthdata module)

### DIFF
--- a/src/fetchez/modules/earthdata.py
+++ b/src/fetchez/modules/earthdata.py
@@ -172,6 +172,7 @@ class EarthData(FetchModule):
         w, e, s, n = self.region
         harmony_data = {
             "bbox": f"{w},{s},{e},{n}",
+            "forceAsync": True,
         }
 
         start_t = self._format_date(self.time_start)


### PR DESCRIPTION
## Description

* Adds 'forceAsyc: True' to the harmony request in earthdata module

---

#### Checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [x] If needed, `CHANGELOG.md` updated
- [x] If needed, docs and/or `README.md` updated
- [x] If needed, unit tests added
- [x] All checks passing (comment `pre-commit.ci autofix` if pre-commit is failing)
- [ ] At least one approval


<!-- readthedocs-preview fetchez start -->
---
:mag: Docs preview: https://fetchez--273.org.readthedocs.build/en/273/

<!-- readthedocs-preview fetchez end -->