### PR TITLE
Pass region through dtype-based reader lookup in registry

### DIFF
--- a/src/fetchez/registry.py
+++ b/src/fetchez/registry.py
@@ -566,7 +566,7 @@ class ReaderRegistry(PluginRegistry):
                 reader = cls.get_reader_for_dtype(term)
                 if reader:
                     logger.debug(f"Found `{reader.name}` for data-type: `{term}`")
-                    return reader(src, **kwargs)
+                    return reader(src, region=region, **kwargs)
 
         _ext = src.split(".")[-1]
         logger.debug(f"No reader dtype found, checking `{_ext}` in extensions")


### PR DESCRIPTION
## Summary
- `ReaderRegistry.get_reader` extracts `region` as its own keyword argument, separate from `**kwargs`, and is expected to re-pass it to the constructed reader.
- #271 fixed this for the profile-based lookup path, but the dtype-based lookup path (`get_reader_for_dtype`, used when a data type like `ATL03` has no registered YAML profile) still called `reader(src, **kwargs)` without `region`, so the reader's `region` always came through as `None`.
- Downstream in `globato`'s ICESat-2 ATL03 reader, this caused `self.region` to be `None`, crashing with `AttributeError: 'NoneType' object has no attribute 'to_shapely'` in `_get_bldg_tree`.

## Test plan
- [x] Reverted the fix and reproduced `AttributeError: 'NoneType' object has no attribute 'to_shapely'` calling `globato.read(..., data_type="ATL03", region=...)` against a cached ATL03 granule.
- [x] Restored the fix and confirmed the same call completes without error, reaching past the `_get_bldg_tree` call site that previously crashed.

<!-- readthedocs-preview fetchez start -->
---
:mag: Docs preview: https://fetchez--274.org.readthedocs.build/en/274/

<!-- readthedocs-preview fetchez end -->