### PR TITLE
harmony jsondecodeerror logger

### DIFF
--- a/src/fetchez/modules/earthdata.py
+++ b/src/fetchez/modules/earthdata.py
@@ -18,6 +18,7 @@ import os
 import time
 import datetime
 import logging
+import requests
 from tqdm import tqdm
 from typing import Dict, Optional
 

--- a/src/fetchez/modules/earthdata.py
+++ b/src/fetchez/modules/earthdata.py
@@ -188,7 +188,16 @@ class EarthData(FetchModule):
         )
 
         if req and req.status_code in [200, 201, 202]:
-            return req.json()
+            try:
+                return req.json()
+            except requests.exceptions.JSONDecodeError:
+                logger.error(
+                    "Harmony API returned HTML instead of JSON. You likely need to log into "
+                    "https://urs.earthdata.nasa.gov and explicitly approve the 'Harmony' application "
+                    "in your profile, or your credentials dropped during a redirect."
+                )
+                logger.debug(f"Response snippet: {req.text[:500]}")
+                return None
 
         logger.error(
             f"Harmony request failed: {req.status_code if req else 'No Response'}"


### PR DESCRIPTION
## Description

* Adds a logger message for harmony JSONDecodeError in earthdata module. The user likely has to approve the harmony app in their earthdata account before they can use the automated harmony access in earthdata. This gives them such a message. This should only need to be done once.

---

#### Checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [x] If needed, `CHANGELOG.md` updated
- [x] If needed, docs and/or `README.md` updated
- [x] If needed, unit tests added
- [x] All checks passing (comment `pre-commit.ci autofix` if pre-commit is failing)
- [ ] At least one approval


<!-- readthedocs-preview fetchez start -->
---
:mag: Docs preview: https://fetchez--275.org.readthedocs.build/en/275/

<!-- readthedocs-preview fetchez end -->