### PR TITLE
requests.session in core for authentication redirects, earthdata auth…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,7 @@ module = [
     "pystac_client",
     "planetary_computer",
     "copernicusmarine",
+    "fsspec.*",
 ]
 ignore_missing_imports = true
 

--- a/src/fetchez/core.py
+++ b/src/fetchez/core.py
@@ -450,7 +450,7 @@ class Fetch:
         self.auth = auth
         self.silent = logger.getEffectiveLevel() > logging.INFO
 
-        self.session = fetchezSession(rauth=self.auth, self.headers)
+        self.session = fetchezSession(rauth=self.auth, rheaders=self.headers)
 
     def fetch_req(
         self,

--- a/src/fetchez/core.py
+++ b/src/fetchez/core.py
@@ -167,7 +167,7 @@ def get_raw_credentials(
 
     while not credentials_valid:
         if not username or not password:
-            logger.info(f"\n--- Authentication Required ---")
+            logger.info("\n--- Authentication Required ---")
             logger.info(f"Destination: {authenticator_url}")
             logger.info("Please enter your credentials. If you don't have an account,")
             logger.info(f"register at: {authenticator_url}\n")
@@ -413,6 +413,23 @@ class HttpFile(io.IOBase):
 # =============================================================================
 # Fetch
 # =============================================================================
+class fetchezSession(requests.Session):
+    def __init__(self, rauth=None, rheaders=None, **kwargs):
+        self.rauth = rauth
+        self.rheaders = rheaders or {}
+        super().__init__(**kwargs)
+
+    def rebuild_auth(self, prepared_request, response):
+        """Intercept the security sweep to preserve Earthdata credentials."""
+
+        super().rebuild_auth(prepared_request, response)
+
+        if self.rauth:
+            self.rauth(prepared_request)
+        elif "Authorization" in self.rheaders:
+            prepared_request.headers["Authorization"] = self.rheaders["Authorization"]
+
+
 class Fetch:
     """Fetch class to fetch ftp/http data files"""
 
@@ -423,7 +440,7 @@ class Fetch:
         headers: Dict = R_HEADERS,
         verify: bool = True,
         allow_redirects: bool = True,
-        auth=None,
+        auth: Optional[Any] = None,
     ):
         self.url = url
         self.callback = callback
@@ -433,20 +450,7 @@ class Fetch:
         self.auth = auth
         self.silent = logger.getEffectiveLevel() > logging.INFO
 
-        self.session = requests.Session()
-
-        self._orig_rebuild_auth = self.session.rebuild_auth
-        self.session.rebuild_auth = self._custom_rebuild_auth
-
-    def _custom_rebuild_auth(self, prepared_request, response):
-        """Intercept the security sweep to preserve Earthdata credentials."""
-
-        self._orig_rebuild_auth(prepared_request, response)
-
-        if self.auth:
-            self.auth(prepared_request)
-        elif "Authorization" in self.headers:
-            prepared_request.headers["Authorization"] = self.headers["Authorization"]
+        self.session = fetchezSession(rauth=self.auth, self.headers)
 
     def fetch_req(
         self,

--- a/src/fetchez/core.py
+++ b/src/fetchez/core.py
@@ -154,8 +154,7 @@ def get_userpass(authenticator_url: str) -> Tuple[Optional[str], Optional[str]]:
 
 
 def get_raw_credentials(
-    url: Optional[str] = None,
-    authenticator_url: str = "https://urs.earthdata.nasa.gov"
+    url: Optional[str] = None, authenticator_url: str = "https://urs.earthdata.nasa.gov"
 ) -> Tuple[Optional[str], Optional[str]]:
     """Get raw (username, password) from .netrc or interactive prompt.
     Optionally validate against an HTTP `url`.
@@ -202,8 +201,7 @@ def get_raw_credentials(
 
 
 def get_credentials(
-    url: Optional[str] = None,
-    authenticator_url: str = "https://urs.earthdata.nasa.gov"
+    url: Optional[str] = None, authenticator_url: str = "https://urs.earthdata.nasa.gov"
 ) -> Optional[str]:
     """Wrapper for get_raw_credentials that returns a Base64 Basic Auth string."""
 
@@ -450,7 +448,6 @@ class Fetch:
         elif "Authorization" in self.headers:
             prepared_request.headers["Authorization"] = self.headers["Authorization"]
 
-
     def fetch_req(
         self,
         method: str = "GET",
@@ -461,7 +458,6 @@ class Fetch:
         # timeout: Optional[Union[float, Tuple]] = None,
         timeout: Optional[float] = 30,
         read_timeout: Optional[float] = 120,
-
     ) -> Optional[requests.Response]:
         """Fetch src_url and return the requests object (iterative retry)."""
 

--- a/src/fetchez/core.py
+++ b/src/fetchez/core.py
@@ -153,40 +153,67 @@ def get_userpass(authenticator_url: str) -> Tuple[Optional[str], Optional[str]]:
     return username, password
 
 
-def get_credentials(
-    url: str, authenticator_url: str = "https://urs.earthdata.nasa.gov"
-) -> Optional[str]:
-    """Get user credentials from .netrc or prompt for input.
-    Used for EarthData, etc.
+def get_raw_credentials(
+    url: Optional[str] = None,
+    authenticator_url: str = "https://urs.earthdata.nasa.gov"
+) -> Tuple[Optional[str], Optional[str]]:
+    """Get raw (username, password) from .netrc or interactive prompt.
+    Optionally validate against an HTTP `url`.
     """
 
-    credentials = None
+    credentials_valid = False
     errprefix = ""
 
     username, password = get_userpass(authenticator_url)
 
-    while not credentials:
-        if not username:
-            username = utils.get_username()
-            password = utils.get_password()
+    while not credentials_valid:
+        if not username or not password:
+            logger.info(f"\n--- Authentication Required ---")
+            logger.info(f"Destination: {authenticator_url}")
+            logger.info("Please enter your credentials. If you don't have an account,")
+            logger.info(f"register at: {authenticator_url}\n")
 
+            # Ensure you strip whitespace just in case!
+            username = utils.get_username().strip()
+            password = utils.get_password().strip()
+
+        if not url:
+            # If no validation URL is provided, trust the input and return immediately
+            return username, password
+
+        # Validate credentials against the provided test URL
         cred_str = f"{username}:{password}"
-        credentials = base64.b64encode(cred_str.encode("ascii")).decode("ascii")
+        encoded_creds = base64.b64encode(cred_str.encode("utf-8")).decode("utf-8")
 
-        if url:
-            try:
-                req = Request(url)
-                req.add_header("Authorization", f"Basic {credentials}")
-                opener = build_opener(HTTPCookieProcessor())
-                opener.open(req)
-            except HTTPError:
-                logger.error(f"{errprefix}Incorrect username or password")
-                errprefix = ""
-                credentials = None
-                username = None
-                password = None
+        try:
+            req = Request(url)
+            req.add_header("Authorization", f"Basic {encoded_creds}")
+            opener = build_opener(HTTPCookieProcessor())
+            opener.open(req)
+            credentials_valid = True
+        except HTTPError:
+            logger.error(f"{errprefix}Incorrect username or password")
+            errprefix = ""
+            # Wipe variables so the next loop forces a manual prompt
+            username = None
+            password = None
 
-    return credentials
+    return username, password
+
+
+def get_credentials(
+    url: Optional[str] = None,
+    authenticator_url: str = "https://urs.earthdata.nasa.gov"
+) -> Optional[str]:
+    """Wrapper for get_raw_credentials that returns a Base64 Basic Auth string."""
+
+    username, password = get_raw_credentials(url, authenticator_url)
+
+    if username and password:
+        cred_str = f"{username}:{password}"
+        return base64.b64encode(cred_str.encode("utf-8")).decode("utf-8")
+
+    return None
 
 
 # =============================================================================
@@ -398,13 +425,31 @@ class Fetch:
         headers: Dict = R_HEADERS,
         verify: bool = True,
         allow_redirects: bool = True,
+        auth=None,
     ):
         self.url = url
         self.callback = callback
         self.headers = headers
         self.verify = verify
         self.allow_redirects = allow_redirects
+        self.auth = auth
         self.silent = logger.getEffectiveLevel() > logging.INFO
+
+        self.session = requests.Session()
+
+        self._orig_rebuild_auth = self.session.rebuild_auth
+        self.session.rebuild_auth = self._custom_rebuild_auth
+
+    def _custom_rebuild_auth(self, prepared_request, response):
+        """Intercept the security sweep to preserve Earthdata credentials."""
+
+        self._orig_rebuild_auth(prepared_request, response)
+
+        if self.auth:
+            self.auth(prepared_request)
+        elif "Authorization" in self.headers:
+            prepared_request.headers["Authorization"] = self.headers["Authorization"]
+
 
     def fetch_req(
         self,
@@ -416,6 +461,7 @@ class Fetch:
         # timeout: Optional[Union[float, Tuple]] = None,
         timeout: Optional[float] = 30,
         read_timeout: Optional[float] = 120,
+
     ) -> Optional[requests.Response]:
         """Fetch src_url and return the requests object (iterative retry)."""
 
@@ -431,14 +477,14 @@ class Fetch:
                     current_read_timeout if current_read_timeout else None,
                 )
 
-                req = requests.request(
+                req = self.session.request(
                     method=method,
                     url=self.url,
                     params=params,
                     data=data,
                     json=json,
                     headers=self.headers,
-                    # auth=self.auth,
+                    auth=self.auth,
                     timeout=tupled_timeout,
                     verify=self.verify,
                     allow_redirects=self.allow_redirects,
@@ -588,13 +634,14 @@ class Fetch:
                     mode = "ab"
 
             try:
-                with requests.request(
+                with self.session.request(
                     method=method,
                     url=self.url,
                     stream=True,
                     params=params,
                     # data=data,
                     # json=json,
+                    auth=self.auth,
                     headers=self.headers,
                     timeout=(timeout, read_timeout),
                     verify=self.verify,
@@ -634,31 +681,8 @@ class Fetch:
                         continue
 
                     elif req.status_code in [401, 403]:
-                        # Earthdata/CDSE hack from cudem.fetches.fetches: requests strips Authorization
-                        # headers on cross-domain redirects. If the URL changed and we got a 401/403,
-                        # explicitly re-request the new URL with headers.
-                        if self.url != req.url:
-                            logger.debug(
-                                f"Auth dropped during redirect. Re-requesting: {req.url}"
-                            )
-                            return Fetch(
-                                url=req.url,
-                                callback=self.callback,
-                                headers=self.headers,
-                                verify=self.verify,
-                                allow_redirects=self.allow_redirects,
-                            ).fetch_file(
-                                dst_fn=dst_fn,
-                                params=params,
-                                datatype=datatype,
-                                overwrite=overwrite,
-                                timeout=timeout,
-                                read_timeout=read_timeout,
-                                tries=tries,
-                                check_size=check_size,
-                                verbose=verbose,
-                            )
-                        raise UnboundLocalError("Authentication Failed")
+                        # Unauthorized / Forbidden
+                        raise UnboundLocalError("Authentication Failed / Forbidden")
 
                     elif req.status_code not in [200, 206]:
                         # Fatal error for this attempt

--- a/src/fetchez/modules/copernicus_marine.py
+++ b/src/fetchez/modules/copernicus_marine.py
@@ -52,7 +52,9 @@ class CopernicusMarineSDB(FetchModule):
             dataset_id or "cmems_obs-sdb_glo_phy_comp_my_100m-l4-s2_static"
         )
 
-        self.username, self.password = get_raw_credentials("https://data.marine.copernicus.eu", "https://data.marine.copernicus.eu")
+        self.username, self.password = get_raw_credentials(
+            "https://data.marine.copernicus.eu", "https://data.marine.copernicus.eu"
+        )
         if not self.username or not self.password:
             logger.warning("No credentials found in .netrc for CDSE.")
             return None

--- a/src/fetchez/modules/copernicus_marine.py
+++ b/src/fetchez/modules/copernicus_marine.py
@@ -16,7 +16,7 @@ import os
 import logging
 from fetchez.modules import FetchModule
 from fetchez import cli
-from fetchez.core import get_userpass
+from fetchez.core import get_raw_credentials
 
 try:
     import copernicusmarine
@@ -52,8 +52,7 @@ class CopernicusMarineSDB(FetchModule):
             dataset_id or "cmems_obs-sdb_glo_phy_comp_my_100m-l4-s2_static"
         )
 
-        self.username, self.password = get_userpass("https://data.marine.copernicus.eu")
-
+        self.username, self.password = get_raw_credentials("https://data.marine.copernicus.eu", "https://data.marine.copernicus.eu")
         if not self.username or not self.password:
             logger.warning("No credentials found in .netrc for CDSE.")
             return None
@@ -99,6 +98,6 @@ class CopernicusMarineSDB(FetchModule):
                 )
 
         except Exception as e:
-            logger.error(f"[{self.name}] Official toolkit failed: {e}")
+            logger.exception(f"[{self.name}] Official toolkit failed: {e}")
 
         return self

--- a/src/fetchez/modules/earthdata.py
+++ b/src/fetchez/modules/earthdata.py
@@ -126,7 +126,9 @@ class EarthData(FetchModule):
         )
 
         # Authentication
-        credentials = core.get_credentials("https://urs.earthdata.nasa.gov", "https://urs.earthdata.nasa.gov")
+        credentials = core.get_credentials(
+            "https://urs.earthdata.nasa.gov", "https://urs.earthdata.nasa.gov"
+        )
         if credentials:
             self.headers = {
                 # "Authorization": f"Basic {credentials}",
@@ -175,7 +177,9 @@ class EarthData(FetchModule):
         else:
             status_url = base_url
 
-        req = core.Fetch(status_url, headers=self.headers, auth=self.auth).fetch_req(timeout=10)
+        req = core.Fetch(status_url, headers=self.headers, auth=self.auth).fetch_req(
+            timeout=10
+        )
         if req and req.status_code == 200:
             return req.json()
         return None
@@ -200,9 +204,9 @@ class EarthData(FetchModule):
 
         logger.debug(f"Submitting Harmony Request for {self.short_name}...")
 
-        req = core.Fetch(self._harmony_url, headers=self.headers, auth=self.auth).fetch_req(
-            params=harmony_data, timeout=30
-        )
+        req = core.Fetch(
+            self._harmony_url, headers=self.headers, auth=self.auth
+        ).fetch_req(params=harmony_data, timeout=30)
 
         if req and req.status_code in [200, 201, 202]:
             try:

--- a/src/fetchez/modules/earthdata.py
+++ b/src/fetchez/modules/earthdata.py
@@ -19,6 +19,7 @@ import time
 import datetime
 import logging
 import requests
+from requests.auth import AuthBase
 from tqdm import tqdm
 from typing import Dict, Optional
 
@@ -38,6 +39,19 @@ logger = logging.getLogger(__name__)
 
 CMR_SEARCH_URL = "https://cmr.earthdata.nasa.gov/search/granules.json?"
 HARMONY_BASE_URL = "https://harmony.earthdata.nasa.gov"
+
+
+class EarthdataAuth(AuthBase):
+    """Custom Auth handler that mimics .netrc behavior across redirects."""
+
+    def __init__(self, b64_credentials):
+        self.b64_credentials = b64_credentials
+
+    def __call__(self, r):
+        # Only inject the Authorization header for NASA Earthdata domains
+        if "earthdata.nasa.gov" in r.url.lower():
+            r.headers["Authorization"] = f"Basic {self.b64_credentials}"
+        return r
 
 
 # =============================================================================
@@ -112,14 +126,16 @@ class EarthData(FetchModule):
         )
 
         # Authentication
-        credentials = core.get_credentials("https://urs.earthdata.nasa.gov")
+        credentials = core.get_credentials("https://urs.earthdata.nasa.gov", "https://urs.earthdata.nasa.gov")
         if credentials:
             self.headers = {
-                "Authorization": f"Basic {credentials}",
+                # "Authorization": f"Basic {credentials}",
                 "User-Agent": core.DEFAULT_USER_AGENT,
             }
+            self.auth = EarthdataAuth(credentials)
         else:
             self.headers = {}
+            self.auth = None
             logger.warning(
                 "Could not retrieve EarthData credentials. Public data might fail."
             )
@@ -159,7 +175,7 @@ class EarthData(FetchModule):
         else:
             status_url = base_url
 
-        req = core.Fetch(status_url, headers=self.headers).fetch_req(timeout=10)
+        req = core.Fetch(status_url, headers=self.headers, auth=self.auth).fetch_req(timeout=10)
         if req and req.status_code == 200:
             return req.json()
         return None
@@ -184,7 +200,7 @@ class EarthData(FetchModule):
 
         logger.debug(f"Submitting Harmony Request for {self.short_name}...")
 
-        req = core.Fetch(self._harmony_url, headers=self.headers).fetch_req(
+        req = core.Fetch(self._harmony_url, headers=self.headers, auth=self.auth).fetch_req(
             params=harmony_data, timeout=30
         )
 
@@ -195,7 +211,7 @@ class EarthData(FetchModule):
                 logger.error(
                     "Harmony API returned HTML instead of JSON. You likely need to log into "
                     "https://urs.earthdata.nasa.gov and explicitly approve the 'Harmony' application "
-                    "in your profile, or your credentials dropped during a redirect."
+                    "in your profile, or your authentication has been rejected."
                 )
                 logger.debug(f"Response snippet: {req.text[:500]}")
                 return None
@@ -306,7 +322,7 @@ class EarthData(FetchModule):
     def _run_harmony_subset(self):
         """Execute Harmony Subset Job."""
 
-        logger.info(f"id: {self.subset_job_id}")
+        logger.info(f"Harmony ID: {self.subset_job_id}")
         if not self.subset_job_id:
             status = self.harmony_make_request()
             if status and "jobID" in status:
@@ -386,7 +402,7 @@ class EarthData(FetchModule):
                             break
 
                     except Exception as e:
-                        logger.error(f"Harmony polling failed: {e}")
+                        logger.exception(f"Harmony polling failed: {e}")
                         time.sleep(15)
 
     def run(self):

--- a/src/fetchez/modules/earthdata.py
+++ b/src/fetchez/modules/earthdata.py
@@ -356,6 +356,7 @@ class EarthData(FetchModule):
                         state = status.get("status", "unknown")
 
                         if state == "successful":
+                            pbar.update(100 - pbar.n)
                             logger.debug("Harmony Job Successful. Processing links...")
                             for link in status.get("links", []):
                                 href = link.get("href", "")

--- a/src/fetchez/modules/earthdata.py
+++ b/src/fetchez/modules/earthdata.py
@@ -137,7 +137,7 @@ class EarthData(FetchModule):
             self.auth = EarthdataAuth(credentials)
         else:
             self.headers = {}
-            self.auth = None
+            # self.auth = None
             logger.warning(
                 "Could not retrieve EarthData credentials. Public data might fail."
             )

--- a/src/fetchez/utils.py
+++ b/src/fetchez/utils.py
@@ -204,14 +204,14 @@ def get_username():
     username = ""
     while not username:
         username = input("username: ")
-    return username
+    return username.strip()
 
 
 def get_password():
     password = ""
     while not password:
         password = getpass.getpass("password: ")
-    return password
+    return password.strip()
 
 
 def int_or(val, or_val=None):


### PR DESCRIPTION
… fun and calls

## Description

* Use requests.session in core.Fetch
* Subclass requests.Session to inject authentication when needed
* Removes old earthdata redirect hack in favor of session + auth
* AuthBase EarthDataAuth to handle earthdata authentication

This fixes a [bug noticed in ivert](https://github.com/continuous-dems/ivert/issues/23) where entering user/pass for authentication in earthdata was causing a JSONDecodeError from harmony. requests was using the .netrc file on the system to bypass this bug, but it shows up without a .netrc file and the user is prompted for their user/pass from `get_credentials`. This was solved by subclassing requests.session and BaseAuth to inject authentication at targeted urls...

---

#### Checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [x] If needed, `CHANGELOG.md` updated
- [x] If needed, docs and/or `README.md` updated
- [x] If needed, unit tests added
- [x] All checks passing (comment `pre-commit.ci autofix` if pre-commit is failing)
- [ ] At least one approval


<!-- readthedocs-preview fetchez start -->
---
:mag: Docs preview: https://fetchez--277.org.readthedocs.build/en/277/

<!-- readthedocs-preview fetchez end -->