### PR TITLE
promote pyproj, shapely, pyogrio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,20 +31,22 @@ dependencies = [
     "tqdm",
     "pyyaml",
     "click",
+    "pyproj",
+    "shapely",
+    "pyogrio",
 ]
 
 keywords = ["Geospatial"]
 
 [project.optional-dependencies]
 aws = ["boto3"]
-vector = ["pyproj", "shapely", "pyogrio"]
 bing = ["mercantile"]
 earthdata = ["earthaccess>=0.9.0"]
 stac = ["pystac", "pystac_client", "planetary_computer"]
 marine = ["copernicusmarine"]
 # jupyter = ["jupyterlab", "ipyleaflet", "ipywidgets"]
 
-full = ["fetchez[aws,bing,vector,earthdata,stac]"]
+full = ["fetchez[aws,bing,earthdata,stac]"]
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
## Description

* promotes pyproj, shapely and pyogrio out of optional into standard dependencies
* all optional dependencies should now be module-specific


---

#### Checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [x] If needed, `CHANGELOG.md` updated
- [x] If needed, docs and/or `README.md` updated
- [x] If needed, unit tests added
- [x] All checks passing (comment `pre-commit.ci autofix` if pre-commit is failing)
- [ ] At least one approval


<!-- readthedocs-preview fetchez start -->
---
:mag: Docs preview: https://fetchez--287.org.readthedocs.build/en/287/

<!-- readthedocs-preview fetchez end -->