### PR TITLE
recipe translate to fetchez.recipe

### DIFF
--- a/src/fetchez/cli/recipes.py
+++ b/src/fetchez/cli/recipes.py
@@ -14,7 +14,6 @@ Discoverability and documentation for fetchez recipes.
 import os
 import sys
 import yaml
-import json
 import click
 from fetchez.recipe import Recipe
 from fetchez.registry import RecipeRegistry
@@ -251,5 +250,6 @@ def translate_recipe(name, as_json):
         click.secho("\n--- Translated CLI Command ---\n", fg="cyan", bold=True)
         click.echo(recipe_obj.to_cli())
         click.echo("\n")
+
 
 recipes_group.add_command(schemas_group, name="schemas")

--- a/src/fetchez/cli/recipes.py
+++ b/src/fetchez/cli/recipes.py
@@ -233,6 +233,7 @@ def run_recipe(name):
 )
 def translate_recipe(name, as_json):
     """Translate a YAML recipe into a fetchez CLI command string or JSON."""
+
     base_config = _load_yaml(name)
     if not base_config:
         click.secho(
@@ -240,67 +241,15 @@ def translate_recipe(name, as_json):
         )
         sys.exit(1)
 
+    recipe_obj = Recipe.from_dict(base_config)
+
     if as_json:
         click.secho("\n--- JSON Recipe ---\n", fg="cyan", bold=True)
-        click.echo(json.dumps(base_config, indent=2))
+        click.echo(recipe_obj.to_json())
         click.echo("\n")
-        return
-
-    cmd_parts = ["fetchez run"]
-
-    # Base Pipeline Arguments
-    if "region" in base_config:
-        cmd_parts.append(f"-R {base_config['region']}")
-    if "region_srs" in base_config:
-        cmd_parts.append(f"--region-srs {base_config['region_srs']}")
-    if "execution" in base_config and "threads" in base_config["execution"]:
-        cmd_parts.append(f"--threads {base_config['execution']['threads']}")
-
-    # Global Hooks
-    for hook in base_config.get("global_hooks", []):
-        hook_name = hook.get("name")
-        args = hook.get("args", {})
-        if args:
-            # Join lists with '/' (for weights, matches, etc.) or just use the string value
-            arg_str = ",".join(
-                f"{k}={'/'.join(map(str, v)) if isinstance(v, list) else v}"
-                for k, v in args.items()
-            )
-            cmd_parts.append(f"--global-hook {hook_name}:{arg_str}")
-        else:
-            cmd_parts.append(f"--global-hook {hook_name}")
-
-    # Modules and their specific hooks
-    for mod in base_config.get("modules", []):
-        mod_name = mod.get("module")
-        mod_args = mod.get("args", {})
-
-        # Start the module line
-        mod_cmd = [mod_name]
-
-        # Append Module Arguments (e.g., --weight 3.0)
-        for k, v in mod_args.items():
-            mod_cmd.append(f"--{k.replace('_', '-')} {v}")
-
-        cmd_parts.append(" ".join(mod_cmd))
-
-        # Append specific Module Hooks
-        for hook in mod.get("hooks", []):
-            hook_name = hook.get("name")
-            args = hook.get("args", {})
-            if args:
-                arg_str = ",".join(
-                    f"{k}={'/'.join(map(str, v)) if isinstance(v, list) else v}"
-                    for k, v in args.items()
-                )
-                cmd_parts.append(f"  --hook {hook_name}:{arg_str}")
-            else:
-                cmd_parts.append(f"  --hook {hook_name}")
-
-    # Print out the fully formatted command
-    click.secho("\n--- Translated CLI Command ---\n", fg="cyan", bold=True)
-    click.echo(" \\\n  ".join(cmd_parts))
-    click.echo("\n")
-
+    else:
+        click.secho("\n--- Translated CLI Command ---\n", fg="cyan", bold=True)
+        click.echo(recipe_obj.to_cli())
+        click.echo("\n")
 
 recipes_group.add_command(schemas_group, name="schemas")

--- a/src/fetchez/recipe.py
+++ b/src/fetchez/recipe.py
@@ -113,6 +113,7 @@ class Recipe:
 
     def to_cli(self, executable="fetchez run") -> str:
         """Translate the recipe configuration into a runnable CLI command string."""
+
         cmd_parts = [executable]
 
         # Base Pipeline Arguments

--- a/src/fetchez/recipe.py
+++ b/src/fetchez/recipe.py
@@ -106,6 +106,69 @@ class Recipe:
 
     from_dict = from_file
 
+    def to_json(self, indent=2) -> str:
+        """Serialize the recipe configuration to a JSON string."""
+
+        return json.dumps(self.config, indent=indent)
+
+    def to_cli(self, executable="fetchez run") -> str:
+        """Translate the recipe configuration into a runnable CLI command string."""
+        cmd_parts = [executable]
+
+        # Base Pipeline Arguments
+        if "region" in self.config:
+            cmd_parts.append(f"-R {self.config['region']}")
+        if "region_srs" in self.config:
+            cmd_parts.append(f"--region-srs {self.config['region_srs']}")
+        if "execution" in self.config and "threads" in self.config["execution"]:
+            cmd_parts.append(f"--threads {self.config['execution']['threads']}")
+
+        # Global Hooks
+        for hook in self.config.get("global_hooks", []):
+            hook_name = hook.get("name") or hook.get("preset")
+            args = hook.get("args", {})
+            if args:
+                arg_str = ",".join(
+                    f"{k}={'/'.join(map(str, v)) if isinstance(v, list) else v}"
+                    for k, v in args.items()
+                )
+                cmd_parts.append(f"--global-hook {hook_name}:{arg_str}")
+            else:
+                cmd_parts.append(f"--global-hook {hook_name}")
+
+        # Modules & Bundles
+        for mod in self.config.get("modules", []):
+            if isinstance(mod, str):
+                cmd_parts.append(mod)
+                continue
+
+            mod_name = mod.get("module") or mod.get("bundle") or mod.get("recipe")
+            mod_args = mod.get("args", {})
+
+            # Start the module segment
+            mod_cmd = [mod_name]
+
+            # Append Module Arguments (e.g., --weight 3.0)
+            for k, v in mod_args.items():
+                mod_cmd.append(f"--{k.replace('_', '-')} {v}")
+
+            cmd_parts.append(" ".join(mod_cmd))
+
+            # Append specific Module Hooks
+            for hook in mod.get("hooks", []):
+                hook_name = hook.get("name") or hook.get("preset")
+                args = hook.get("args", {})
+                if args:
+                    arg_str = ",".join(
+                        f"{k}={'/'.join(map(str, v)) if isinstance(v, list) else v}"
+                        for k, v in args.items()
+                    )
+                    cmd_parts.append(f"  --hook {hook_name}:{arg_str}")
+                else:
+                    cmd_parts.append(f"  --hook {hook_name}")
+
+        return " \\\n  ".join(cmd_parts)
+
     def _check_integrity(self):
         """Ensures the fetchez version meets the recipe's minimum requirements."""
 


### PR DESCRIPTION
## Description

* Moves the recipe 'translate' functionality out of the cli and into fetchez.recipe


---

#### Checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [x] If needed, `CHANGELOG.md` updated
- [x] If needed, docs and/or `README.md` updated
- [x] If needed, unit tests added
- [x] All checks passing (comment `pre-commit.ci autofix` if pre-commit is failing)
- [ ] At least one approval


<!-- readthedocs-preview fetchez start -->
---
:mag: Docs preview: https://fetchez--288.org.readthedocs.build/en/288/

<!-- readthedocs-preview fetchez end -->