### PR TITLE
remove now un-needed checks for pyproj, pyogrio and shapely

### DIFF
--- a/src/fetchez/core.py
+++ b/src/fetchez/core.py
@@ -33,12 +33,7 @@ import requests
 import lxml.etree
 import lxml.html as lh
 
-try:
-    from shapely.geometry import Polygon, mapping
-
-    HAS_SHAPELY = True
-except ImportError:
-    HAS_SHAPELY = False
+from shapely.geometry import Polygon, mapping
 
 from . import utils
 from . import __version__
@@ -336,10 +331,10 @@ class iso_xml:
 
             out_poly = [[lon, lat] for lat, lon in out_poly]
             if geom:
-                if HAS_SHAPELY:
+                try:
                     poly = Polygon(out_poly)
                     geojson_dict = mapping(poly)
-                else:
+                except Exception:
                     geojson_dict = {"type": "Polygon", "coordinates": [out_poly]}
 
                 return geojson_dict

--- a/src/fetchez/fred.py
+++ b/src/fetchez/fred.py
@@ -23,13 +23,8 @@ from . import utils
 from . import config
 from . import spatial
 
-try:
-    from shapely.geometry import shape
-    # from shapely.strtree import STRtree
-
-    HAS_SHAPELY = True
-except ImportError:
-    HAS_SHAPELY = False
+from shapely.geometry import shape
+# from shapely.strtree import STRtree
 
 logger = logging.getLogger(__name__)
 
@@ -168,10 +163,7 @@ class FRED:
 
         search_geom = None
         if region is not None and spatial.region_valid_p(region):
-            if HAS_SHAPELY:
-                search_geom = spatial.region_to_shapely(region)
-            else:
-                search_geom = None  # TODO: update to manually make one from region!
+            search_geom = spatial.region_to_shapely(region)
 
         if region:
             r_str = ",".join(f"{x:.2f}" for x in region)
@@ -198,16 +190,12 @@ class FRED:
                 continue
 
             if search_geom and geom:
-                if HAS_SHAPELY:
-                    try:
-                        feat_shape = shape(geom)
-                        if not search_geom.intersects(feat_shape):
-                            continue
-                    except Exception:
+                try:
+                    feat_shape = shape(geom)
+                    if not search_geom.intersects(feat_shape):
                         continue
-                else:
-                    # TODO: Basic bounding box check (if Shapely missing)
-                    pass
+                except Exception:
+                    continue
 
             results.append(props)
 

--- a/src/fetchez/modules/arcticdem.py
+++ b/src/fetchez/modules/arcticdem.py
@@ -20,19 +20,8 @@ from fetchez.modules import FetchModule
 from fetchez import cli
 from fetchez import utils
 
-try:
-    from pyproj import Transformer
-
-    HAS_PYPROJ = True
-except ImportError:
-    HAS_PYPROJ = False
-
-try:
-    from pyogrio.raw import read
-
-    HAS_PYOGRIO = True
-except ImportError:
-    HAS_PYOGRIO = False
+from pyproj import Transformer
+from pyogrio.raw import read
 
 logger = logging.getLogger(__name__)
 
@@ -109,14 +98,6 @@ class ArcticDEM(FetchModule):
         """Run the ArcticDEM fetches module."""
 
         if self.wgs_region is None:
-            return self
-
-        if not HAS_PYPROJ:
-            logger.error("Missing libraries. Run: `pip install pyproj`")
-            return self
-
-        if not HAS_PYOGRIO:
-            logger.error("Missing libraries. Please run: pip install pyogrio")
             return self
 
         idx_zip_name = os.path.basename(ARCTIC_DEM_INDEX_URL)

--- a/src/fetchez/modules/base.py
+++ b/src/fetchez/modules/base.py
@@ -18,16 +18,11 @@ import json
 import hashlib
 from typing import List, Dict, Any
 
+import pyproj
+
 from fetchez import spatial
 from fetchez import utils
 from fetchez.core import Fetch
-
-try:
-    import pyproj
-
-    HAS_PYPROJ = True
-except ImportError:
-    HAS_PYPROJ = False
 
 logger = logging.getLogger(__name__)
 
@@ -68,14 +63,13 @@ class FetchModule:
                 is_geographic = False
                 srs_str = str(self.region.srs).strip()
 
-                if HAS_PYPROJ:
-                    try:
-                        crs = pyproj.CRS.from_user_input(srs_str)
-                        is_geographic = crs.is_geographic
-                    except Exception as e:
-                        logger.debug(f"PyProj failed to parse CRS '{srs_str}': {e}")
+                try:
+                    crs = pyproj.CRS.from_user_input(srs_str)
+                    is_geographic = crs.is_geographic
+                except Exception as e:
+                    logger.debug(f"PyProj failed to parse CRS '{srs_str}': {e}")
 
-                if not HAS_PYPROJ or not is_geographic:
+                if not is_geographic:
                     srs_upper = srs_str.upper()
                     if any(
                         x in srs_upper

--- a/src/fetchez/modules/bluetopo.py
+++ b/src/fetchez/modules/bluetopo.py
@@ -27,12 +27,7 @@ try:
 except ImportError:
     HAS_BOTO = False
 
-try:
-    from pyogrio.raw import read
-
-    HAS_PYOGRIO = True
-except ImportError:
-    HAS_PYOGRIO = False
+from pyogrio.raw import read
 
 from fetchez import core
 from fetchez.modules import FetchModule
@@ -104,12 +99,6 @@ class BlueTopo(FetchModule):
 
         if not HAS_BOTO:
             logger.error('This module requires "boto3". Please install it to proceed.')
-            return self
-
-        if not HAS_PYOGRIO:
-            logger.error(
-                'This module requires "pyogrio" to parse the spatial index. Please install it via: pip install pyogrio'
-            )
             return self
 
         if self.wgs_region is None:

--- a/src/fetchez/modules/dav.py
+++ b/src/fetchez/modules/dav.py
@@ -18,43 +18,20 @@ from urllib.parse import urljoin
 from typing import List, Dict, Optional, Any
 import requests
 
-try:
-    from pyproj import CRS, Transformer
-
-    HAS_PYPROJ = True
-except ImportError:
-    HAS_PYPROJ = False
-
-# try:
-#     import fiona
-
-#     HAS_FIONA = True
-# except ImportError:
-#     HAS_FIONA = False
-
-try:
-    from pyogrio.raw import read
-
-    HAS_PYOGRIO = True
-except ImportError:
-    HAS_PYOGRIO = False
+from pyproj import CRS, Transformer
+from pyogrio.raw import read
 
 from fetchez import core
 from fetchez.modules import FetchModule
 from fetchez import utils
 from fetchez import cli
 
+from fetchez.modules.tnm import TheNationalMap
+
 logger = logging.getLogger(__name__)
 
 DAV_API_URL = "https://coast.noaa.gov/dataviewer/api/v1/search/missions"
 DAV_HEADERS = {"Content-Type": "application/json"}
-
-try:
-    from fetchez.modules.tnm import TheNationalMap
-
-    HAS_TNM = True
-except ImportError:
-    HAS_TNM = False
 
 
 # =============================================================================
@@ -210,14 +187,6 @@ class DAV(FetchModule):
     def _process_index_shapefile(self, shp_path: str, dataset_id: str, data_type: str):
         """Parse the downloaded index shapefile using PyShp + PyProj."""
 
-        if not HAS_PYPROJ:
-            logger.error("Missing libraries. Run: `pip install pyproj`")
-            return
-
-        if not HAS_PYOGRIO:
-            logger.error("Missing libraries. Run: `pip install pyogrio`")
-            return
-
         prj_path = shp_path.replace(".shp", ".prj")
         target_crs = None
 
@@ -369,7 +338,7 @@ class DAV(FetchModule):
             if not bulk_url:
                 continue
 
-            if is_usgs and HAS_TNM:
+            if is_usgs:
                 project_name = self._extract_usgs_project(bulk_url)
 
                 if project_name:

--- a/src/fetchez/modules/earthdata.py
+++ b/src/fetchez/modules/earthdata.py
@@ -28,12 +28,7 @@ from fetchez.modules import FetchModule
 from fetchez import spatial
 from fetchez import cli
 
-try:
-    from shapely.geometry import Polygon
-
-    HAS_SHAPELY = True
-except ImportError:
-    HAS_SHAPELY = False
+from shapely.geometry import Polygon
 
 logger = logging.getLogger(__name__)
 
@@ -276,30 +271,28 @@ class EarthData(FetchModule):
 
         # Prepare Shapely Polygon for precise filtering
         search_geom = None
-        if HAS_SHAPELY:
-            search_geom = spatial.region_to_shapely(self.wgs_region)
+        search_geom = spatial.region_to_shapely(self.wgs_region)
 
         for entry in entries:
             # Spatial Filtering (Refine BBox search)
             geom_valid = True
 
             # Check Polygon Intersection if Shapely available
-            if HAS_SHAPELY and search_geom and "polygons" in entry:
-                try:
-                    # CMR Polygons are list of lists: [['lat1 lon1 lat2 lon2 ...']]
-                    poly_str = entry["polygons"][0][0]
-                    coords = [float(x) for x in poly_str.split()]
+            try:
+                # CMR Polygons are list of lists: [['lat1 lon1 lat2 lon2 ...']]
+                poly_str = entry["polygons"][0][0]
+                coords = [float(x) for x in poly_str.split()]
 
-                    lats = coords[::2]
-                    lons = coords[1::2]
-                    points = list(zip(lons, lats))
+                lats = coords[::2]
+                lons = coords[1::2]
+                points = list(zip(lons, lats))
 
-                    granule_poly = Polygon(points)
+                granule_poly = Polygon(points)
 
-                    if not search_geom.intersects(granule_poly):
-                        geom_valid = False
-                except Exception:
-                    pass
+                if not search_geom.intersects(granule_poly):
+                    geom_valid = False
+            except Exception:
+                pass
 
             if geom_valid:
                 for link in entry.get("links", []):

--- a/src/fetchez/modules/proj.py
+++ b/src/fetchez/modules/proj.py
@@ -20,12 +20,7 @@ from fetchez.modules import FetchModule
 from fetchez import cli
 from fetchez import spatial
 
-try:
-    from shapely.geometry import shape
-
-    HAS_SHAPELY = True
-except ImportError:
-    HAS_SHAPELY = False
+from shapely.geometry import shape
 
 logger = logging.getLogger(__name__)
 
@@ -81,14 +76,13 @@ class PROJ(FetchModule):
             return True
 
         # Geometry Check (if Shapely is available)
-        if HAS_SHAPELY and grid_geom:
-            try:
-                user_poly = spatial.region_to_shapely(self.wgs_region)
-                grid_poly = shape(grid_geom)
+        try:
+            user_poly = spatial.region_to_shapely(self.wgs_region)
+            grid_poly = shape(grid_geom)
 
-                return user_poly.intersects(grid_poly)
-            except Exception as e:
-                logger.debug(f"Shapely intersection failed: {e}, falling back to bbox.")
+            return user_poly.intersects(grid_poly)
+        except Exception as e:
+            logger.debug(f"Shapely intersection failed: {e}, falling back to bbox.")
 
         # BBox Fallback (Fast but rough)
         if grid_bbox:

--- a/src/fetchez/spatial.py
+++ b/src/fetchez/spatial.py
@@ -19,28 +19,11 @@ import logging
 import warnings
 from typing import Union, List, Tuple, Optional
 
-try:
-    from shapely.geometry import shape, box
-    from shapely import from_wkb
-
-    HAS_SHAPELY = True
-except ImportError:
-    HAS_SHAPELY = False
-
-try:
-    from pyproj import Transformer
-
-    HAS_PYPROJ = True
-except ImportError:
-    HAS_PYPROJ = False
-
-try:
-    from pyogrio.raw import read
-    from pyogrio import read_info
-
-    HAS_PYOGRIO = True
-except ImportError:
-    HAS_PYOGRIO = False
+from shapely.geometry import shape, box
+from shapely import from_wkb
+from pyproj import Transformer
+from pyogrio.raw import read
+from pyogrio import read_info
 
 from fetchez.utils import str_or, _linspace
 
@@ -335,14 +318,12 @@ class Region:
         return str(self)
 
     def to_shapely(self):
-        if not HAS_SHAPELY:
-            return None
         return box(self.xmin, self.ymin, self.xmax, self.ymax)
 
     def to_wkt(self):
-        if HAS_SHAPELY:
+        try:
             return self.to_shapely().wkt
-        else:
+        except Exception:
             # Simple fallback WKT
             return (
                 f"POLYGON (({self.xmin} {self.ymin}, {self.xmin} {self.ymax}, "
@@ -517,12 +498,6 @@ class Region:
             if self.srs.upper() == dst_srs.upper():
                 return self
 
-        if not HAS_PYPROJ:
-            logger.error(
-                "The 'pyproj' library is required to warp regions. Run: pip install pyproj"
-            )
-            return self
-
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             # always_xy=True ensures we don't get tripped up by strict EPSG axis orders
@@ -544,81 +519,10 @@ class Region:
 # =============================================================================
 # Helper / Parser Functions
 # =============================================================================
-# def region_from_fiona(fn: str) -> Optional[List[Region]]:
-#     """Parse the bounding box of any OGR-supported vector file using Fiona.
-
-#     This function has been depreciated in favor of `region_from_vector`
-#     """
-
-#     if not os.path.exists(fn):
-#         return None
-
-#     try:
-#         import fiona
-#     except ImportError:
-#         logger.error(
-#             f"Fiona is required to parse '{os.path.basename(fn)}'. Run: pip install fiona"
-#         )
-#         return None
-
-#     regions = []
-#     try:
-#         with fiona.open(fn, "r") as src:
-#             # --- Single region of whole vector: ---
-#             # minx, miny, maxx, maxy = src.bounds
-#             # return [Region(minx, maxx, miny, maxy)]
-#             # if src.crs and src.crs.to_epsg() != 4326:
-#             #     if not HAS_PYPROJ:
-#             #         logger.error("The 'pyproj' library is required to warp regions. Run: pip install pyproj")
-#             #     else:
-#             #         original_region = Region
-
-#             #         transformer = Transformer.from_crs(src.crs, "EPSG:4326", always_xy=True)
-#             #         # Transform the corners
-#             #         xs, ys = zip(*[
-#             #             transformer.transform(minx, miny),
-#             #             transformer.transform(minx, maxy),
-#             #             transformer.transform(maxx, maxy),
-#             #             transformer.transform(maxx, miny)
-#             #         ])
-#             #         minx, maxx = min(xs), max(xs)
-#             #         miny, maxy = min(ys), max(ys)
-
-#             # --- Region for each feature in vector: ---
-#             for feature in src:
-#                 geom = shape(feature.get("geometry"))
-#                 if geom:
-#                     minx, miny, maxx, maxy = geom.bounds
-#                     # regions.append(Region(minx, maxx, miny, maxy))
-#                     original_region = Region(minx, maxx, miny, maxy)
-
-#                     if src.crs and src.crs.to_epsg() != 4326:
-#                         if not HAS_PYPROJ:
-#                             logger.error(
-#                                 "The 'pyproj' library is required to warp regions. Run: pip install pyproj"
-#                             )
-#                         else:
-#                             original_region.srs = src.crs
-#                             original_region.warp()
-
-#                     regions.append(original_region)
-
-#     except Exception as e:
-#         logger.exception(f"Failed to parse vector bounds from {fn}: {e}")
-
-#     return regions
-
-
 def region_from_vector(fn: str, single_region: bool = False) -> Optional[List[Region]]:
     """Parse the bounding box of any OGR-supported vector file using pygorio."""
 
     if not os.path.exists(fn):
-        return None
-
-    if not HAS_PYOGRIO:
-        logger.error(
-            f"pyogrio is required to parse '{os.path.basename(fn)}'. Run: pip install pyogrio"
-        )
         return None
 
     regions = []
@@ -630,13 +534,8 @@ def region_from_vector(fn: str, single_region: bool = False) -> Optional[List[Re
             global_region = Region(minx, maxx, miny, maxy)
 
             if info.get("crs"):
-                if not HAS_PYPROJ:
-                    logger.error(
-                        "The 'pyproj' library is required to warp regions. Run: pip install pyproj"
-                    )
-                else:
-                    global_region.srs = info.get("crs")
-                    global_region.warp()
+                global_region.srs = info.get("crs")
+                global_region.warp()
 
             return [global_region]
 
@@ -644,20 +543,14 @@ def region_from_vector(fn: str, single_region: bool = False) -> Optional[List[Re
         # --- Region for each feature in vector: ---
         if len(geometry_wkb) > 0:
             # Convert WKB directly to shapely geometries
-            # We also filter out any None/Null geometries
             for geom in from_wkb(geometry_wkb):
                 if geom:
                     minx, miny, maxx, maxy = geom.bounds
                     original_region = Region(minx, maxx, miny, maxy)
 
                     if meta.get("crs"):  # and meta.get("crs").to_epsg() != 4326:
-                        if not HAS_PYPROJ:
-                            logger.error(
-                                "The 'pyproj' library is required to warp regions. Run: pip install pyproj"
-                            )
-                        else:
-                            original_region.srs = meta.get("crs")
-                            original_region.warp()
+                        original_region.srs = meta.get("crs")
+                        original_region.warp()
 
                     regions.append(original_region)
 
@@ -688,14 +581,13 @@ def region_from_geojson(fn: str) -> Optional[List[Region]]:
             if not geom:
                 continue
 
-            if HAS_SHAPELY:
-                b = shape(geom).bounds  # (minx, miny, maxx, maxy)
-                # min_x, min_y = min(min_x, b[0]), min(min_y, b[1])
-                # max_x, max_y = max(max_x, b[2]), max(max_y, b[3])
-                min_x, min_y, max_x, max_y = b
-                valid = True
+            b = shape(geom).bounds  # (minx, miny, maxx, maxy)
+            # min_x, min_y = min(min_x, b[0]), min(min_y, b[1])
+            # max_x, max_y = max(max_x, b[2]), max(max_y, b[3])
+            min_x, min_y, max_x, max_y = b
+            valid = True
 
-            elif "coordinates" in geom:
+            if not valid and "coordinates" in geom:
                 xs, ys = [], []
                 for x, y in _extract_coords(geom["coordinates"]):
                     xs.append(x)
@@ -746,7 +638,6 @@ def parse_region(input_r: Union[str, List]) -> List[Region]:
 
     def _parse_crs(r_string: str) -> tuple[str, str | None]:
         # Parse the crs; either appended with `@` or `,`
-
         r_string = r_string
         target_crs = None
         if "@" in r_string:
@@ -760,6 +651,7 @@ def parse_region(input_r: Union[str, List]) -> List[Region]:
 
     target_crs = None
     regions = []
+
     # Single String
     if isinstance(input_r, str):
         input_r, target_crs = _parse_crs(input_r)
@@ -800,10 +692,6 @@ def parse_region(input_r: Union[str, List]) -> List[Region]:
         if input_r is not None:
             logger.warning(f"Failed to parse region {input_r}")
 
-    # else:
-    #     for r in regions:
-    #         r.srs = target_crs
-
     return regions
 
 
@@ -834,6 +722,7 @@ def region_valid_p(region, check_xy=True):
 
     if isinstance(region, Region):
         return region.valid_p(check_xy)
+
     # Handle tuples via temporary Region object
     return Region.from_list(region).valid_p(check_xy) if region else False
 
@@ -855,7 +744,7 @@ def region_to_shapely(region: Tuple[float, float, float, float]):
     shapely regions are not: (minx, miny, maxx, maxy)
     """
 
-    if not region or not HAS_SHAPELY:
+    if not region:
         return None
 
     west, east, south, north = region
@@ -865,13 +754,12 @@ def region_to_shapely(region: Tuple[float, float, float, float]):
 def region_to_wkt(region: Tuple[float, float, float, float]):
     """Convert a fetchez region (xmin, xmax, ymin, ymax) to WKT (via shapely)"""
 
-    if HAS_SHAPELY:
-        polygon = region_to_shapely(region)
-        if polygon:
-            return polygon.wkt
-
-    w, e, s, n = region
-    return f"POLYGON (({w} {s}, {w} {n}, {e} {n}, {e} {s}, {w} {s}))"
+    polygon = region_to_shapely(region)
+    if polygon:
+        return polygon.wkt
+    else:
+        w, e, s, n = region
+        return f"POLYGON (({w} {s}, {w} {n}, {e} {n}, {e} {s}, {w} {s}))"
 
 
 def _extract_coords(coords):
@@ -896,13 +784,6 @@ def region_to_bbox(region: Tuple[float, float, float, float]):
 
 def region_to_geojson_geom(region: Tuple[float, float, float, float]):
     w, e, s, n = region
-    # geom = {
-    #     "type": "Polygon",
-    #     "coordinates": [[
-    #         [w, s], [e, s], [e, n], [w, n], [w, s]
-    #     ]]
-    # }
-
     return {
         "type": "Polygon",
         "coordinates": [[[w, s], [w, n], [e, n], [e, s], [w, s]]],

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,8 +1,7 @@
 # test_core.py
 
-import pytest
 from fetchez.modules import FetchModule
-from fetchez.spatial import Region, HAS_PYPROJ
+from fetchez.spatial import Region
 
 
 def test_fetchmodule_default_region():
@@ -35,7 +34,6 @@ def test_fetchmodule_add_results():
     assert mod.results[0]["data_type"] == "raster"
 
 
-@pytest.mark.skipif(not HAS_PYPROJ, reason="Requires pyproj for warping")
 def test_fetchmodule_projected_dual_region():
     """Ensure a projected region generates a distinct WGS84 region for API calls."""
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -71,13 +71,11 @@ def test_optional_dependencies_are_protected():
 
     OPTIONAL_IMPORTS = {
         "boto3",
-        "pyproj",
-        "shapely",
         "mercantile",
         "earthaccess",
         "pystac",
         "pystac_client",
-        "fiona",
+        "planetary_computer",
         "copernicusmarine",
     }
 

--- a/tests/test_spatial.py
+++ b/tests/test_spatial.py
@@ -1,8 +1,7 @@
 # test_spatial.py
 
-import pytest
 from fetchez.spatial import parse_region
-from fetchez.spatial import Region, HAS_PYPROJ
+from fetchez.spatial import Region
 
 
 def test_parse_region_with_epsg():
@@ -13,7 +12,6 @@ def test_parse_region_with_epsg():
     assert regions[0].srs == "epsg:4326"
 
 
-@pytest.mark.skipif(not HAS_PYPROJ, reason="Requires pyproj for warping")
 def test_region_warp_utm_to_wgs84():
     """Test that a projected region correctly transforms to WGS84 (EPSG:4326)."""
 


### PR DESCRIPTION
## Description

* Now that pyroj, shapely and pyogrio are standard dependencies, we no longer need to check for them when they're used

---

#### Checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [x] If needed, `CHANGELOG.md` updated
- [x] If needed, docs and/or `README.md` updated
- [x] If needed, unit tests added
- [x] All checks passing (comment `pre-commit.ci autofix` if pre-commit is failing)
- [ ] At least one approval


<!-- readthedocs-preview fetchez start -->
---
:mag: Docs preview: https://fetchez--290.org.readthedocs.build/en/290/

<!-- readthedocs-preview fetchez end -->