### PR TITLE
recipes cli bugfix; collision of recipe name and local fn name

### DIFF
--- a/src/fetchez/cli/recipes.py
+++ b/src/fetchez/cli/recipes.py
@@ -277,9 +277,11 @@ def run_recipe(name, region, region_srs, outdir, shared_cache):
 
     click.secho(f"Executing YAML recipe: {name}...", fg="cyan", bold=True)
 
+    base_config = None
     if os.path.exists(name):
         base_config = _load_yaml(name)
-    else:
+
+    if not base_config:
         meta = RecipeRegistry.get_yaml(name)
         if not meta:
             click.secho(f"Error: Recipe '{name}' not found.", fg="red")

--- a/src/fetchez/recipe.py
+++ b/src/fetchez/recipe.py
@@ -455,9 +455,18 @@ class Recipe:
                                 name = parent_hook.get("name")
 
                                 if name in hook_map:
-                                    parent_hook.update(hook_map[name])
+                                    # parent_hook.update(hook_map[name])
+                                    merged_args = parent_hook.get("args", {}).copy()
+                                    merged_args.update(hook_map[name].get("args", {}))
+                                    parent_hook["args"] = merged_args
+
                         else:
-                            parent_hooks.extend(user_args)
+                            # parent_hooks.extend(user_args)
+                            parent_hooks = (
+                                copy.deepcopy(parent_hooks)
+                                if parent_hooks
+                                else copy.deepcopy(user_args)
+                            )
 
                     # Recursively expand the child hooks, passing down the merged args
                     expanded_child_hooks = self._expand_hooks(


### PR DESCRIPTION
## Description

* recipes cli would crash if a directory or file existed with the same name as recipe
* fix syntax bugs in fetchez.recipe


---

#### Checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [x] If needed, `CHANGELOG.md` updated
- [x] If needed, docs and/or `README.md` updated
- [x] If needed, unit tests added
- [x] All checks passing (comment `pre-commit.ci autofix` if pre-commit is failing)
- [ ] At least one approval


<!-- readthedocs-preview fetchez start -->
---
:mag: Docs preview: https://fetchez--304.org.readthedocs.build/en/304/

<!-- readthedocs-preview fetchez end -->