### PR TITLE
keyboard interrupt in core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### BUGFIX
+ - keyboard interrupt wouldn't correctly get passed to the concurrent threads and got looped into the logging library; moving the try/except to inside the with concurrent and adding a logging.debug in the keyboardinterrupt solves this and now is responsive and acting as expected.
 
 ## [0.7.0 - 2026-07-22]
 ### ADDED

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,6 +16,6 @@ authors:
 
     website: https://fetchez.readthedocs.io/
 title: "Fetchez"
-version: 0.7.0
-date-released: 2026-07-22
+version: 0.7.1
+date-released: 2026-07-27
 url: "https://github.com/continuous-dems/fetchez"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center"><strong>Fetch geospatial data with ease.</strong></p>
 
 <p align="center">
-  <a href="https://github.com/continuous-dems/fetchez"><img src="https://img.shields.io/badge/version-0.7.0-blue.svg" alt="Version"></a>
+  <a href="https://github.com/continuous-dems/fetchez"><img src="https://img.shields.io/badge/version-0.7.1-blue.svg" alt="Version"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License"></a>
   <a href="https://www.python.org/"><img src="https://img.shields.io/badge/python-3.12+-yellow.svg" alt="Python"></a>
   <a href="https://badge.fury.io/py/fetchez"><img src="https://badge.fury.io/py/fetchez.svg" alt="PyPI version"></a>

--- a/src/fetchez/core.py
+++ b/src/fetchez/core.py
@@ -922,6 +922,9 @@ def run_fetchez(modules: List[Any], threads: int = 3, global_hooks=None):
                 disable=silent,
             ) as pbar:
                 for future in concurrent.futures.as_completed(futures):
+                    if STOP_EVENT.is_set():
+                        # If GDAL swallowed the exception earlier, force it to raise now!
+                        raise KeyboardInterrupt("Pipeline aborted by user.")
                     mod, original_entry = futures[future]
                     file_name = os.path.basename(original_entry.get("dst_fn", "item"))
                     short_name = (

--- a/src/fetchez/core.py
+++ b/src/fetchez/core.py
@@ -906,8 +906,8 @@ def run_fetchez(modules: List[Any], threads: int = 3, global_hooks=None):
     final_results_with_owner = []
     active_hooks_full = []
 
-    try:
-        with concurrent.futures.ThreadPoolExecutor(max_workers=threads) as executor:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=threads) as executor:
+        try:
             futures = {
                 executor.submit(_fetch_worker, mod, entry, verbose=True): (mod, entry)
                 for mod, entry in all_entries
@@ -938,13 +938,14 @@ def run_fetchez(modules: List[Any], threads: int = 3, global_hooks=None):
                     except Exception as e:
                         logger.error(f"Worker exception: {e}")
                         original_entry.update({"status": -1})
+                        continue
 
                     # --- File Hooks ---
                     gf_hooks = [h for h in global_hooks if h.stage == "file"]
                     lf_hooks = [h for h in mod.hooks if h.stage == "file"]
 
                     active_file_hooks = utils.merge_hooks(lf_hooks, gf_hooks)
-                    active_hooks_full.append(active_file_hooks)
+                    active_hooks_full.extend(active_file_hooks)
 
                     current_entries = [(mod, original_entry)]
 
@@ -968,7 +969,7 @@ def run_fetchez(modules: List[Any], threads: int = 3, global_hooks=None):
                         key=lambda hook: 0 if hook.name == "stream-init" else 1
                     )
 
-                    active_hooks_full.append(active_stream_hooks)
+                    active_hooks_full.extend(active_stream_hooks)
                     if active_stream_hooks:
                         # If stream hooks exist but no stream is active.
                         has_stream = any(
@@ -1032,28 +1033,29 @@ def run_fetchez(modules: List[Any], threads: int = 3, global_hooks=None):
                     final_results_with_owner.extend(processed_entries)
                     pbar.update(1)
 
-    except KeyboardInterrupt:
-        STOP_EVENT.set()
-        executor.shutdown(wait=False, cancel_futures=True)
-        raise
+        except KeyboardInterrupt:
+            STOP_EVENT.set()
+            logger.debug("stop set")
+            executor.shutdown(wait=False, cancel_futures=True)
+            raise
 
-    finally:
-        # --- Teardown The Hook(s) ---
-        logger.debug("Running teardown for all hooks...")
+        finally:
+            # --- Teardown The Hook(s) ---
+            logger.debug("Running teardown for all hooks...")
 
-        all_possible_hooks = active_hooks_full
-        for h in global_hooks:
-            all_possible_hooks.append(h)
-        for m in modules:
-            for h in m.hooks:
+            all_possible_hooks = active_hooks_full
+            for h in global_hooks:
                 all_possible_hooks.append(h)
+            for m in modules:
+                for h in m.hooks:
+                    all_possible_hooks.append(h)
 
-        for hook in all_possible_hooks:
-            if hasattr(hook, "teardown"):
-                try:
-                    hook.teardown()
-                except Exception as e:
-                    logger.error(f"Teardown failed for hook '{hook.name}': {e}")
+            for hook in all_possible_hooks:
+                if hasattr(hook, "teardown"):
+                    try:
+                        hook.teardown()
+                    except Exception as e:
+                        logger.error(f"Teardown failed for hook '{hook.name}': {e}")
 
     # --- Post Hooks ---
     # Module-level Post-Hooks

--- a/src/fetchez/recipe.py
+++ b/src/fetchez/recipe.py
@@ -324,7 +324,16 @@ class Recipe:
 
         # Ids that make a dataset truly unique within a module
         ids = []
-        for key in ["datatype", "datasets", "formats", "layer", "product", "survey_id", "url", "path"]:
+        for key in [
+            "datatype",
+            "datasets",
+            "formats",
+            "layer",
+            "product",
+            "survey_id",
+            "url",
+            "path",
+        ]:
             if key in args:
                 ids.append(f"{key}={args[key]}")
 

--- a/src/fetchez/recipe.py
+++ b/src/fetchez/recipe.py
@@ -324,7 +324,7 @@ class Recipe:
 
         # Ids that make a dataset truly unique within a module
         ids = []
-        for key in ["datatype", "datasets", "formats", "layer", "product"]:
+        for key in ["datatype", "datasets", "formats", "layer", "product", "survey_id", "url", "path"]:
             if key in args:
                 ids.append(f"{key}={args[key]}")
 


### PR DESCRIPTION
## Description

* BUGFIX: keyboard interrupt wouldn't correctly get passed to the concurrent threads and got looped into the logging library; moving the try/except to inside the with concurrent and adding a logging.debug in the keyboardinterrupt solves this and now is responsive and acting as expected.


---

#### Checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [x] If needed, `CHANGELOG.md` updated
- [x] If needed, docs and/or `README.md` updated
- [x] If needed, unit tests added
- [x] All checks passing (comment `pre-commit.ci autofix` if pre-commit is failing)
- [ ] At least one approval


<!-- readthedocs-preview fetchez start -->
---
:mag: Docs preview: https://fetchez--305.org.readthedocs.build/en/305/

<!-- readthedocs-preview fetchez end -->