### PR TITLE
add regions cli test from globato

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,12 +1,24 @@
+# test_cli.py
+import pytest
 import subprocess
 import sys
 
 from fetchez.utils import parse_hook_string
+from fetchez.cli import cli
+
+from click.testing import CliRunner
 
 # Testing CLI using subprocess
 
 # CMD will run Fetchez
 CMD = [sys.executable, "-m", "fetchez.cli.__init__"]
+
+
+@pytest.fixture
+def runner():
+    """Fixture to provide a Click CliRunner for all tests."""
+
+    return CliRunner()
 
 
 def run_fetchez(args):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -97,3 +97,14 @@ def test_parse_hook_string_no_args():
     hook = parse_hook_string("unzip")
     assert hook["name"] == "unzip"
     assert hook.get("args") is None
+
+
+def test_region_echo_bbox(runner):
+    """Test the spatial parsing engine (No network required)."""
+
+    result = runner.invoke(
+        cli, ["regions", "echo", "-R", "-120/-119/34/35", "-F", "gmt"]
+    )
+
+    assert result.exit_code == 0
+    assert "-120.0/-119.0/34.0/35.0" in result.output.strip()


### PR DESCRIPTION
## Description

* Moves the cli regions test from globato to fetchez.

---

#### Checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [x] If needed, `CHANGELOG.md` updated
- [x] If needed, docs and/or `README.md` updated
- [x] If needed, unit tests added
- [x] All checks passing (comment `pre-commit.ci autofix` if pre-commit is failing)
- [ ] At least one approval


<!-- readthedocs-preview fetchez start -->
---
:mag: Docs preview: https://fetchez--306.org.readthedocs.build/en/306/

<!-- readthedocs-preview fetchez end -->