### PR TITLE
add modifiers/schemas to api, include verbosity and dryrun in api.get

### DIFF
--- a/src/fetchez/api.py
+++ b/src/fetchez/api.py
@@ -104,7 +104,7 @@ def search_schemas(term) -> Dict[str, Any]:
     return _search_registry(SchemaRegistry, term)
 
 
-def list_modifier() -> Dict[str, Any]:
+def list_modifiers() -> Dict[str, Any]:
     return _search_registry(ModifierRegistry)
 
 
@@ -135,6 +135,7 @@ def search(term: str) -> Dict[str, Dict[str, Any]]:
         "hooks": _search_registry(HookRegistry, term),
         "recipes": _search_registry(RecipeRegistry, term),
         "schemas": _search_registry(SchemaRegistry, term),
+        "modifiers": _search_registry(ModifierRegistry, term),
         "presets": _search_registry(PresetRegistry, term),
         "profiles": _search_registry(ProfileRegistry, term),
     }
@@ -147,6 +148,8 @@ def get(
     outdir: Optional[str] = None,
     threads: int = 4,
     hooks: Optional[List[str]] = None,
+    dry_run: bool = False,
+    verbose: bool = True,
     **kwargs,
 ) -> List[str]:
     """Fetch data from a module in one line.
@@ -158,11 +161,17 @@ def get(
         outdir: Where to save files (default: ./<module>).
         threads: Parallel download threads.
         hooks: List of hook strings (e.g. ['unzip', 'audit']).
+        dry_run: Don't download any data.
+        verbose: Run in verbose mode.
         **kwargs: Arguments passed directly to the module (year=..., datatype=...).
 
     Returns:
         A list of absolute paths to the downloaded files.
     """
+
+    from .recipe import setup_logging
+
+    setup_logging(verbose)
 
     ModuleRegistry.load_all()
     HookRegistry.load_all()
@@ -222,6 +231,20 @@ def get(
         logger.debug(f"No results found for {module} with given parameters.")
         return []
 
+    if dry_run:
+        manifest = []
+        for _mod, entry in mod_instance.results:
+            source = (
+                entry.get("url") or entry.get("path") or entry.get("name") or str(entry)
+            )
+            manifest.append(source)
+
+        if verbose:
+            logger.info(f"DRY RUN: Found {len(manifest)} items to fetch.")
+            for item in manifest:
+                logger.info(f"  -> {item}")
+        return manifest
+
     # Grab the final results from the fetchez pipeline
     final_results = run_fetchez([mod_instance], threads=threads)
     downloaded_files = []
@@ -238,6 +261,8 @@ def run_recipe(
     target: str,
     region: Optional[str] = None,
     region_srs: Optional[str] = "EPSG:4326",
+    modifiers: Optional[List[str | Dict]] = None,
+    schemas: Optional[List[str]] = None,
 ) -> bool:
     """Execute a YAML recipe.
 
@@ -269,8 +294,14 @@ def run_recipe(
     if region_srs:
         base_config["region_srs"] = region_srs
 
+    if modifiers:
+        base_config["modifiers"] = base_config.get("modifiers", []) + modifiers
+    if schemas:
+        base_config["schemas"] = base_config.get("schemas", []) + schemas
+
     try:
-        Recipe.from_file(base_config).run()
+        # Recipe.from_file(base_config).run()
+        Recipe(base_config).run()
         return True
     except Exception as e:
         logger.error(f"Failed to run recipe '{target}': {e}")

--- a/src/fetchez/cli/recipes.py
+++ b/src/fetchez/cli/recipes.py
@@ -225,10 +225,10 @@ def recipe_validate(name, schema):
         click.secho(f"Validating against {schema_name} schema...", nl=False)
         _valid, _errors = schema.validate(recipe_config)
         if not _valid:
-            click.secho("FAIL", fg="red", bold=True)
+            click.secho("FAIL", fg="red")
             errors.extend(_errors)
         else:
-            click.secho("PASS", fg="green", bold=True)
+            click.secho("PASS", bg="green")
 
     is_valid = len(errors) == 0
 


### PR DESCRIPTION
## Description

* secures modifiers and schemas in the api
* Adds 'verbose' and 'dryrun' options to api.get

---

#### Checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [x] If needed, `CHANGELOG.md` updated
- [x] If needed, docs and/or `README.md` updated
- [x] If needed, unit tests added
- [x] All checks passing (comment `pre-commit.ci autofix` if pre-commit is failing)
- [ ] At least one approval


<!-- readthedocs-preview fetchez start -->
---
:mag: Docs preview: https://fetchez--312.org.readthedocs.build/en/312/

<!-- readthedocs-preview fetchez end -->