### PR TITLE
use outdir in fetchez_cache, rename check-modules to validate-recipes

### DIFF
--- a/src/fetchez/modules/base.py
+++ b/src/fetchez/modules/base.py
@@ -178,7 +178,7 @@ class FetchModule:
 
         # BLACKLIST
         ignored_keys = {
-            "outdir",
+            # "outdir",
             "hooks",
             "results",
             "status",

--- a/src/fetchez/recipes/schemas/validate_modules.py
+++ b/src/fetchez/recipes/schemas/validate_modules.py
@@ -21,7 +21,8 @@ from .base import BaseSchema
 
 
 class CheckModules(BaseSchema):
-    name = "check-modules"
+    name = "validate-recipe"
+    meta_desc = "validate the recipe for syntax, missing modules and hooks, and valid arguments."
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)


### PR DESCRIPTION
## Description

* include outdir in fetchez cache hash
* rename check-modules to validate-recipes

---

#### Checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [x] If needed, `CHANGELOG.md` updated
- [x] If needed, docs and/or `README.md` updated
- [x] If needed, unit tests added
- [x] All checks passing (comment `pre-commit.ci autofix` if pre-commit is failing)
- [ ] At least one approval


<!-- readthedocs-preview fetchez start -->
---
:mag: Docs preview: https://fetchez--315.org.readthedocs.build/en/315/

<!-- readthedocs-preview fetchez end -->