### PR TITLE
start over if server doesn't support resume

### DIFF
--- a/src/fetchez/core.py
+++ b/src/fetchez/core.py
@@ -680,6 +680,17 @@ class Fetch:
                                 os.rename(part_fn, dst_fn)
                                 return 0
 
+                            # Remove the Range header if the server doesn't support resume
+                            if resume_byte_pos > 0 and req.status_code == 200:
+                                logger.warning(
+                                    f"Server ignored resume request for {os.path.basename(dst_fn)}. "
+                                    "Restarting download from scratch."
+                                )
+                                mode = "wb"
+                                resume_byte_pos = 0
+                                if "Range" in self.headers:
+                                    del self.headers["Range"]
+
                             # Error Codes
                             if req.status_code == 416:
                                 # Range No Good: Local file is likely corrupt.


### PR DESCRIPTION
## Description

* Add a check in fetchez.core to make sure the server supports resume before appending the entire file onto the failed part.

---

#### Checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [x] If needed, `CHANGELOG.md` updated
- [x] If needed, docs and/or `README.md` updated
- [x] If needed, unit tests added
- [ ] All checks passing (comment `pre-commit.ci autofix` if pre-commit is failing)
- [ ] At least one approval


<!-- readthedocs-preview fetchez start -->
---
:mag: Docs preview: https://fetchez--320.org.readthedocs.build/en/320/

<!-- readthedocs-preview fetchez end -->