### PR TITLE
-D required in cache clear

### DIFF
--- a/src/fetchez/cli/cache.py
+++ b/src/fetchez/cli/cache.py
@@ -33,7 +33,7 @@ def cache_group():
 
 
 @cache_group.command("info", cls=FetchezMainCommand)
-@click.option("-D", "--dir", default=".", help="Target directory to inspect.")
+@click.option("-D", "--dir", required=True, help="Target directory to inspect.")
 def cache_info(dir):
     """Display information about local cache usage."""
 
@@ -67,7 +67,9 @@ def cache_info(dir):
 
 
 @cache_group.command("clear", cls=FetchezMainCommand)
-@click.option("-D", "--dir", default=".", help="Target directory to clear.")
+@click.option(
+    "-D", "--dir", default=".", required=True, help="Target directory to clear."
+)
 def cache_clear(dir):
     """Safely delete the local Fetchez cache."""
 

--- a/src/fetchez/recipe.py
+++ b/src/fetchez/recipe.py
@@ -765,6 +765,7 @@ class Recipe:
                     iteration_config_modified = modifier.apply(
                         iteration_config_modified
                     )
+                iteration_config = copy.deepcopy(iteration_config_modified)
 
                 # Inject outdir for shared caching
                 for mod in iteration_config.get("modules", []):
@@ -791,7 +792,7 @@ class Recipe:
                 for schema in schemas:
                     logger.info(f"Validating recipe with {schema.name} schema")
                     iteration_valid, iteration_errors = schema.validate(
-                        iteration_config_modified
+                        iteration_config
                     )
                     if not iteration_valid:
                         errors.extend(iteration_errors)
@@ -800,8 +801,8 @@ class Recipe:
                     logger.warning(
                         f"The recipe is invalid based on defined schemas: {errors}"
                     )
-                else:
-                    iteration_config = copy.deepcopy(iteration_config_modified)
+                # else:
+                #     iteration_config = copy.deepcopy(iteration_config_modified)
 
                 # Initialize Hooks and Modules ( to python classes )
                 try:

--- a/src/fetchez/utils.py
+++ b/src/fetchez/utils.py
@@ -165,8 +165,8 @@ class FetchezMainGroup(click.Group):
 class FetchezMainCommand(click.Command):
     """Custom command to colorize the main CLI commands."""
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+    # def __init__(self, **kwargs):
+    #     super().__init__(**kwargs)
 
     def format_usage(self, ctx, formatter):
         usage_pieces = self.collect_usage_pieces(ctx)


### PR DESCRIPTION
## Description

* -D should be required in `cache` command so you don't clobber files by accident.
* Bugfix in fetchez.recipe: iteration_config got re-copied to modified after changing order of operations.


---

#### Checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [x] If needed, `CHANGELOG.md` updated
- [x] If needed, docs and/or `README.md` updated
- [x] If needed, unit tests added
- [x] All checks passing (comment `pre-commit.ci autofix` if pre-commit is failing)
- [ ] At least one approval


<!-- readthedocs-preview fetchez start -->
---
:mag: Docs preview: https://fetchez--322.org.readthedocs.build/en/322/

<!-- readthedocs-preview fetchez end -->