### PR TITLE
Make sure local paths are different

### DIFF
--- a/src/fetchez/core.py
+++ b/src/fetchez/core.py
@@ -597,7 +597,7 @@ class Fetch:
                     import shutil
 
                     Path(dst_fn).parent.mkdir(parents=True, exist_ok=True)
-                    if not Path(src_path) == Path(dst_fn):
+                    if not Path(src_path).resolve() == Path(dst_fn).resolve():
                         shutil.copy2(src_path, dst_fn)
                     return 0
                 except Exception as e:


### PR DESCRIPTION
## Description

* resolve the paths in core when checking if paths are equal

---

#### Checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [x] If needed, `CHANGELOG.md` updated
- [x] If needed, docs and/or `README.md` updated
- [x] If needed, unit tests added
- [x] All checks passing (comment `pre-commit.ci autofix` if pre-commit is failing)
- [ ] At least one approval


<!-- readthedocs-preview fetchez start -->
---
:mag: Docs preview: https://fetchez--338.org.readthedocs.build/en/338/

<!-- readthedocs-preview fetchez end -->