### PR TITLE
Recipe bugfix when ignore_failures is on

### DIFF
--- a/src/fetchez/recipe.py
+++ b/src/fetchez/recipe.py
@@ -727,23 +727,23 @@ class Recipe:
 
                 self.to_markdown(iteration_config, batch_name)
 
-                try:
-                    for mod in modules_to_run:
+                for mod in modules_to_run:
+                    try:
                         mod.run()
-                except Exception as e:
-                    if ignore_failures:
-                        logger.error(f"[{mod.name}] Module execution failed: {e}")
-                        logger.warning(
-                            f"[{mod.name}] 'ignore-failures' is SET. "
-                            "Pipeline will continue, but your final output may be incomplete!"
-                        )
-                    else:
-                        # Default behavior: Fail and abort
-                        logger.critical(
-                            f"[{mod.name}] Fatal error encountered. Aborting pipeline to prevent incomplete data generation. "
-                            "Set 'ignore_failures' if you wish to bypass this."
-                        )
-                        raise
+                    except Exception as e:
+                        if ignore_failures:
+                            logger.error(f"[{mod.name}] Module execution failed: {e}")
+                            logger.warning(
+                                f"[{mod.name}] 'ignore-failures' is SET. "
+                                "Pipeline will continue, but your final output may be incomplete!"
+                            )
+                        else:
+                            # Default behavior: Fail and abort
+                            logger.critical(
+                                f"[{mod.name}] Fatal error encountered. Aborting pipeline to prevent incomplete data generation. "
+                                "Set 'ignore_failures' if you wish to bypass this."
+                            )
+                            raise
 
                 try:
                     tracemalloc.start()


### PR DESCRIPTION
## Description

* Bugfix in recipe.py mod.run loop which caused the fetching to stop at first failure even when ignore_failures was on.


---

#### Checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [x] If needed, `CHANGELOG.md` updated
- [x] If needed, docs and/or `README.md` updated
- [x] If needed, unit tests added
- [x] All checks passing (comment `pre-commit.ci autofix` if pre-commit is failing)
- [ ] At least one approval


<!-- readthedocs-preview fetchez start -->
---
:mag: Docs preview: https://fetchez--347.org.readthedocs.build/en/347/

<!-- readthedocs-preview fetchez end -->