### PR TITLE
add environmental variables to get_credentials and earthdata

### DIFF
--- a/src/fetchez/core.py
+++ b/src/fetchez/core.py
@@ -184,9 +184,14 @@ def get_raw_credentials(
             logger.info("Please enter your credentials. If you don't have an account,")
             logger.info(f"register at: {authenticator_url}\n")
 
-            # Ensure you strip whitespace just in case!
-            username = utils.get_username().strip()
-            password = utils.get_password().strip()
+            username = utils.get_username()
+            password = utils.get_password()
+            if env_user and env_pass:
+                os.environ[env_user] = username
+                os.environ[env_pass] = password
+                username, password = get_userpass(
+                    authenticator_url, env_user=env_user, env_pass=env_pass
+                )
 
         if not url:
             # If no validation URL is provided, trust the input and return immediately

--- a/src/fetchez/core.py
+++ b/src/fetchez/core.py
@@ -127,9 +127,21 @@ def xml2py(node) -> Optional[Dict]:
     return texts
 
 
-def get_userpass(authenticator_url: str) -> Tuple[Optional[str], Optional[str]]:
+def get_userpass(
+    authenticator_url: str,
+    env_user: Optional[str] = None,
+    env_pass: Optional[str] = None,
+) -> Tuple[Optional[str], Optional[str]]:
     """Retrieve username and password from netrc for a given URL."""
 
+    # Environmental Variables
+    if env_user and env_pass:
+        _user = os.environ.get(env_user)
+        _pass = os.environ.get(env_pass)
+        if _user and _pass:
+            return _user, _pass
+
+    # .netrc
     username = None
     password = None
     try:
@@ -149,7 +161,10 @@ def get_userpass(authenticator_url: str) -> Tuple[Optional[str], Optional[str]]:
 
 
 def get_raw_credentials(
-    url: Optional[str] = None, authenticator_url: str = "https://urs.earthdata.nasa.gov"
+    url: Optional[str] = None,
+    authenticator_url: str = "https://urs.earthdata.nasa.gov",
+    env_user: Optional[str] = None,
+    env_pass: Optional[str] = None,
 ) -> Tuple[Optional[str], Optional[str]]:
     """Get raw (username, password) from .netrc or interactive prompt.
     Optionally validate against an HTTP `url`.
@@ -158,7 +173,9 @@ def get_raw_credentials(
     credentials_valid = False
     errprefix = ""
 
-    username, password = get_userpass(authenticator_url)
+    username, password = get_userpass(
+        authenticator_url, env_user=env_user, env_pass=env_pass
+    )
 
     while not credentials_valid:
         if not username or not password:
@@ -196,11 +213,16 @@ def get_raw_credentials(
 
 
 def get_credentials(
-    url: Optional[str] = None, authenticator_url: str = "https://urs.earthdata.nasa.gov"
+    url: Optional[str] = None,
+    authenticator_url: str = "https://urs.earthdata.nasa.gov",
+    env_user: Optional[str] = None,
+    env_pass: Optional[str] = None,
 ) -> Optional[str]:
     """Wrapper for get_raw_credentials that returns a Base64 Basic Auth string."""
 
-    username, password = get_raw_credentials(url, authenticator_url)
+    username, password = get_raw_credentials(
+        url, authenticator_url, env_user=env_user, env_pass=env_pass
+    )
 
     if username and password:
         cred_str = f"{username}:{password}"
@@ -415,7 +437,7 @@ class fetchezSession(requests.Session):
         super().__init__(**kwargs)
 
     def rebuild_auth(self, prepared_request, response):
-        """Intercept the security sweep to preserve Earthdata credentials."""
+        """Intercept the security sweep to preserve credentials."""
 
         super().rebuild_auth(prepared_request, response)
 

--- a/src/fetchez/core.py
+++ b/src/fetchez/core.py
@@ -186,12 +186,6 @@ def get_raw_credentials(
 
             username = utils.get_username()
             password = utils.get_password()
-            if env_user and env_pass:
-                os.environ[env_user] = username
-                os.environ[env_pass] = password
-                username, password = get_userpass(
-                    authenticator_url, env_user=env_user, env_pass=env_pass
-                )
 
         if not url:
             # If no validation URL is provided, trust the input and return immediately

--- a/src/fetchez/core.py
+++ b/src/fetchez/core.py
@@ -184,8 +184,9 @@ def get_raw_credentials(
             logger.info("Please enter your credentials. If you don't have an account,")
             logger.info(f"register at: {authenticator_url}\n")
 
-            username = utils.get_username()
-            password = utils.get_password()
+            with HOOK_LOCK:
+                username = utils.get_username()
+                password = utils.get_password()
 
         if not url:
             # If no validation URL is provided, trust the input and return immediately

--- a/src/fetchez/modules/earthdata.py
+++ b/src/fetchez/modules/earthdata.py
@@ -122,7 +122,10 @@ class EarthData(FetchModule):
 
         # Authentication
         credentials = core.get_credentials(
-            "https://urs.earthdata.nasa.gov", "https://urs.earthdata.nasa.gov"
+            url="https://urs.earthdata.nasa.gov",
+            authenticator_url="https://urs.earthdata.nasa.gov",
+            env_user="EARTHDATA_USERNAME",
+            env_pass="EARTHDATA_PASSWORD",
         )
         if credentials:
             self.headers = {


### PR DESCRIPTION
## Description

* Adds options to core.get_credentials to use environmental variables
* Used new options in core.get_credentials in earthdata module

---

#### Checklist

- [x] PR title is descriptive
- [x] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [x] If needed, `CHANGELOG.md` updated
- [x] If needed, docs and/or `README.md` updated
- [x] If needed, unit tests added
- [x] All checks passing (comment `pre-commit.ci autofix` if pre-commit is failing)
- [ ] At least one approval


<!-- readthedocs-preview fetchez start -->
---
:mag: Docs preview: https://fetchez--350.org.readthedocs.build/en/350/

<!-- readthedocs-preview fetchez end -->